### PR TITLE
added is_leaf flag, optimized iterators, inlined functions

### DIFF
--- a/hhds/tree.hpp
+++ b/hhds/tree.hpp
@@ -52,8 +52,8 @@ static constexpr short NUM_SHORT_DEL = CHUNK_MASK;        // Number of short del
 static constexpr Tree_pos INVALID = 0;                 // This is invalid for all pointers other than parent
 static constexpr Tree_pos ROOT    = 1 << CHUNK_SHIFT;  // ROOT ID
 
-static constexpr short CHUNK_BITS  = 50;  // Number of chunks in a tree node
-static constexpr short SHORT_DELTA = 18;  // Amount of short delta allowed
+static constexpr short CHUNK_BITS  = 49;  // adjusted from 50 to 49
+static constexpr short SHORT_DELTA = 17;  // adjusted from 18 to 17
 
 static constexpr uint64_t MAX_TREE_SIZE = 1LL << CHUNK_BITS;  // Maximum number of chunks in the tree
 
@@ -73,6 +73,9 @@ private:
 
   // Track number of occupied short delta pointers
   unsigned short num_short_del_occ : CHUNK_SHIFT;
+
+  // leaf flag
+  bool is_leaf : 1;
 
   // Short (delta) child pointers
   __int128 first_child_s;
@@ -109,6 +112,7 @@ public:
       , first_child_l(INVALID)
       , last_child_l(INVALID)
       , num_short_del_occ(0)
+      , is_leaf(true)
       , first_child_s(INVALID)
       , last_child_s(INVALID) {}
 
@@ -120,6 +124,7 @@ public:
       , first_child_l(INVALID)
       , last_child_l(INVALID)
       , num_short_del_occ(0)
+      , is_leaf(true)
       , first_child_s(INVALID)
       , last_child_s(INVALID) {}
 
@@ -137,6 +142,9 @@ public:
   // Getter for num_occ
   unsigned short get_num_short_del_occ() const { return num_short_del_occ; }
 
+  // getter for is_leaf
+  bool get_is_leaf() const { return is_leaf; }
+
   // Setters
   void set_parent(Tree_pos p) { parent = p; }
   void set_next_sibling(Tree_pos ns) { next_sibling = ns; }
@@ -151,11 +159,14 @@ public:
   // Setter for num_short_del_occ
   void set_num_short_del_occ(unsigned short num) { num_short_del_occ = num; }
 
+  // Setter for is_leaf
+  void set_is_leaf(bool leaf) { is_leaf = leaf; }
+
   // Operators
   constexpr bool operator==(const Tree_pointers& other) const {
     return parent == other.parent && next_sibling == other.next_sibling && prev_sibling == other.prev_sibling
            && first_child_l == other.first_child_l && last_child_l == other.last_child_l && first_child_s == other.first_child_s
-           && last_child_s == other.last_child_s;
+           && last_child_s == other.last_child_s && is_leaf == other.is_leaf;
   }
 
   constexpr bool operator!=(const Tree_pointers& other) const { return !(*this == other); }
@@ -243,6 +254,10 @@ private:
       if (pointers_stack[parent_id >> CHUNK_SHIFT].get_first_child_l() == INVALID) {
         pointers_stack[parent_id >> CHUNK_SHIFT].set_first_child_l(child_id >> CHUNK_SHIFT);
       }
+
+      // update is_leaf flag
+      pointers_stack[parent_id >> CHUNK_SHIFT].set_is_leaf(false);
+
       return parent_id;
     }
 
@@ -256,6 +271,9 @@ private:
       if (pointers_stack[parent_chunk_id].get_first_child_s_at(parent_chunk_offset - 1) == INVALID) {
         pointers_stack[parent_chunk_id].set_first_child_s_at(parent_chunk_offset - 1, (child_id >> CHUNK_SHIFT) - parent_chunk_id);
       }
+
+      // update is_leaf flag
+      pointers_stack[parent_chunk_id].set_is_leaf(false);
 
       return parent_id;
     }
@@ -282,12 +300,17 @@ private:
         // Convert the short pointers here to long pointers there
         const auto fc = pointers_stack[parent_chunk_id].get_first_child_s_at(offset);
         const auto lc = pointers_stack[parent_chunk_id].get_last_child_s_at(offset);
-        pointers_stack[new_chunk_id].set_first_child_l(fc + parent_chunk_id);
-        pointers_stack[new_chunk_id].set_last_child_l(lc + parent_chunk_id);
+        if (fc != INVALID) {
+          pointers_stack[new_chunk_id].set_first_child_l(fc + parent_chunk_id);
+          pointers_stack[new_chunk_id].set_last_child_l(lc + parent_chunk_id);
+          pointers_stack[new_chunk_id].set_is_leaf(false);
+        }
 
         // Update the parent pointer of all children of this guy
         // THIS LOOKS LIKE A BOTTLENECK -> Will iterate over all ~ (children / 8) chunks
-        _update_parent_pointer((fc + parent_chunk_id) << CHUNK_SHIFT, new_chunk_id << CHUNK_SHIFT);
+        if (fc != INVALID) {
+          _update_parent_pointer((fc + parent_chunk_id) << CHUNK_SHIFT, new_chunk_id << CHUNK_SHIFT);
+        }
 
         // Remove the short pointers in the old chunk
         pointers_stack[parent_chunk_id].set_first_child_s_at(offset, INVALID);
@@ -306,6 +329,9 @@ private:
         pointers_stack[new_chunk].set_parent(my_new_parent);
       }
     }
+
+    // update is_leaf flag
+    pointers_stack[parent_chunk_id].set_is_leaf(false);
 
     return new_chunks.front() << CHUNK_SHIFT;  // The first one was where the parent was sent
   }
@@ -373,6 +399,7 @@ public:
       std::cout << "Next Sibling: " << pointers_stack[i].get_next_sibling() << " ";
       std::cout << "Prev Sibling: " << pointers_stack[i].get_prev_sibling() << " ";
       std::cout << "Num Occ: " << pointers_stack[i].get_num_short_del_occ() << std::endl;
+      std::cout << "Is Leaf: " << pointers_stack[i].get_is_leaf() << std::endl;
       std::cout << std::endl;
     }
 
@@ -521,16 +548,16 @@ public:
     pre_order_iterator(Tree_pos start, tree<X>* tree) : current(start), tree_ptr(tree) {}
 
     pre_order_iterator& operator++() {
-      auto next = tree_ptr->get_first_child(current);
-      if (next != INVALID) {
-        current = next;
+      if (!tree_ptr->pointers_stack[current >> CHUNK_SHIFT].get_is_leaf()) {
+        // node is not a leaf, move to first child
+        current = tree_ptr->get_first_child(current);
       } else {
-        // See if there is a sibling we can move to
+        // node is a leaf, find next node
         const auto nxt = tree_ptr->get_sibling_next(current);
         if (nxt != INVALID) {
           current = nxt;
         } else {
-          // No more siblings, let's move to an ancestor's sibling
+          // no more siblings, move to an ancestor's sibling
           bool found  = false;
           auto parent = tree_ptr->get_parent(current);
           while (parent != ROOT) {
@@ -589,23 +616,36 @@ public:
     using iterator_category = std::forward_iterator_tag;
     using value_type        = Tree_pos;
     using difference_type   = std::ptrdiff_t;
-    using pointer           = Tree_pos*;
-    using reference         = Tree_pos&;
+    using pointer           = const Tree_pos*;
+    using reference         = const Tree_pos&;
 
     const_pre_order_iterator(Tree_pos start, const tree<X>* tree) : current(start), tree_ptr(tree) {}
 
     const_pre_order_iterator& operator++() {
-      if (tree_ptr->get_first_child(current) != INVALID) {
+      if (!tree_ptr->pointers_stack[current >> CHUNK_SHIFT].get_is_leaf()) {
+        // node is not a leaf, move to first child
         current = tree_ptr->get_first_child(current);
       } else {
-        while (tree_ptr->get_sibling_next(current) == INVALID) {
-          current = tree_ptr->get_parent(current);
-          if (current == INVALID) {
-            break;
+        // node is a leaf, find next node
+        const auto nxt = tree_ptr->get_sibling_next(current);
+        if (nxt != INVALID) {
+          current = nxt;
+        } else {
+          // no more siblings, let's move to an ancestor's sibling
+          bool found  = false;
+          auto parent = tree_ptr->get_parent(current);
+          while (parent != ROOT) {
+            const auto parent_sibling = tree_ptr->get_sibling_next(parent);
+            if (parent_sibling != INVALID) {
+              current = parent_sibling;
+              found   = true;
+              break;
+            }
+            parent = tree_ptr->get_parent(parent);
           }
-        }
-        if (current != INVALID) {
-          current = tree_ptr->get_sibling_next(current);
+          if (!found) {
+            current = INVALID;
+          }
         }
       }
       return *this;
@@ -653,21 +693,26 @@ public:
     using pointer           = Tree_pos*;
     using reference         = Tree_pos&;
 
-    post_order_iterator(Tree_pos start, tree<X>* tree) : current(start), tree_ptr(tree) {}
+    post_order_iterator(Tree_pos start, tree<X>* tree) : current(start), tree_ptr(tree) {
+      // move to the leftmost leaf
+      while (!tree_ptr->pointers_stack[current >> CHUNK_SHIFT].get_is_leaf()) {
+        current = tree_ptr->get_first_child(current);
+      }
+    }
 
     post_order_iterator& operator++() {
-      post_order_iterator temp = *this;
       if (tree_ptr->get_sibling_next(current) != INVALID) {
-        auto next = tree_ptr->get_sibling_next(current);
-        while (tree_ptr->get_sibling_next(next) != INVALID) {
-          next = tree_ptr->get_first_child(next);
+        current = tree_ptr->get_sibling_next(current);
+        while (!tree_ptr->pointers_stack[current >> CHUNK_SHIFT].get_is_leaf()) {
+          current = tree_ptr->get_first_child(current);
         }
-
-        current = next;
       } else {
         current = tree_ptr->get_parent(current);
+        if (current == ROOT) {
+          current = INVALID;
+        }
       }
-      return temp;
+      return *this;
     }
 
     bool operator==(const post_order_iterator& other) const { return current == other.current; }
@@ -702,22 +747,27 @@ public:
     using iterator_category = std::forward_iterator_tag;
     using value_type        = Tree_pos;
     using difference_type   = std::ptrdiff_t;
-    using pointer           = Tree_pos*;
-    using reference         = Tree_pos&;
+    using pointer           = const Tree_pos*;
+    using reference         = const Tree_pos&;
 
-    const_post_order_iterator(Tree_pos start, const tree<X>* tree) : current(start), tree_ptr(tree) {}
+    const_post_order_iterator(Tree_pos start, const tree<X>* tree) : current(start), tree_ptr(tree) {
+      // move to the leftmost leaf
+      while (!tree_ptr->pointers_stack[current >> CHUNK_SHIFT].get_is_leaf()) {
+        current = tree_ptr->get_first_child(current);
+      }
+    }
 
     const_post_order_iterator& operator++() {
-      // post_order_iterator temp = *this;
       if (tree_ptr->get_sibling_next(current) != INVALID) {
-        auto next = tree_ptr->get_sibling_next(current);
-        while (tree_ptr->get_sibling_next(next) != INVALID) {
-          next = tree_ptr->get_first_child(next);
+        current = tree_ptr->get_sibling_next(current);
+        while (!tree_ptr->pointers_stack[current >> CHUNK_SHIFT].get_is_leaf()) {
+          current = tree_ptr->get_first_child(current);
         }
-
-        current = next;
       } else {
         current = tree_ptr->get_parent(current);
+        if (current == ROOT) {
+          current = INVALID;
+        }
       }
       return *this;
     }
@@ -759,7 +809,7 @@ public:
  * @assert If the index is out of range
  */
 template <typename X>
-Tree_pos tree<X>::get_parent(const Tree_pos& curr_index) const {
+inline Tree_pos tree<X>::get_parent(const Tree_pos& curr_index) const {
   I(_check_idx_exists(curr_index), "get_parent: Index out of range");
 
   return pointers_stack[curr_index >> CHUNK_SHIFT].get_parent();
@@ -774,14 +824,10 @@ Tree_pos tree<X>::get_parent(const Tree_pos& curr_index) const {
  * @assert If the index is out of range
  */
 template <typename X>
-bool tree<X>::is_leaf(const Tree_pos& leaf_index) const {
+inline bool tree<X>::is_leaf(const Tree_pos& leaf_index) const {
   I(_check_idx_exists(leaf_index), "is_leaf: Index out of range");
 
-  if (leaf_index & CHUNK_MASK) {
-    return pointers_stack[leaf_index >> CHUNK_SHIFT].get_first_child_s_at((leaf_index & CHUNK_MASK) - 1) == INVALID;
-  } else {
-    return pointers_stack[leaf_index >> CHUNK_SHIFT].get_first_child_l() == INVALID;
-  }
+  return pointers_stack[leaf_index >> CHUNK_SHIFT].get_is_leaf();
 }
 
 /**
@@ -793,7 +839,7 @@ bool tree<X>::is_leaf(const Tree_pos& leaf_index) const {
  * @throws std::out_of_range If the parent index is out of range
  */
 template <typename X>
-Tree_pos tree<X>::get_last_child(const Tree_pos& parent_index) const {
+inline Tree_pos tree<X>::get_last_child(const Tree_pos& parent_index) const {
   I(_check_idx_exists(parent_index), "get_last_child: Parent index out of range");
 
   const auto chunk_id       = (parent_index >> CHUNK_SHIFT);
@@ -823,7 +869,7 @@ Tree_pos tree<X>::get_last_child(const Tree_pos& parent_index) const {
  * @throws std::out_of_range If the parent index is out of range
  */
 template <typename X>
-Tree_pos tree<X>::get_first_child(const Tree_pos& parent_index) const {
+inline Tree_pos tree<X>::get_first_child(const Tree_pos& parent_index) const {
   // if (!_check_idx_exists(parent_index)) {
   //     throw std::out_of_range("get_first_child: Parent index out of range");
   // }
@@ -844,7 +890,7 @@ Tree_pos tree<X>::get_first_child(const Tree_pos& parent_index) const {
   }
 
   // The beginning of the chunk IS the first child (always)
-  return static_cast<Tree_pos>(child_chunk_id << CHUNK_SHIFT);
+  return (child_chunk_id == INVALID) ? INVALID : static_cast<Tree_pos>(child_chunk_id << CHUNK_SHIFT);
 }
 
 /**
@@ -856,7 +902,7 @@ Tree_pos tree<X>::get_first_child(const Tree_pos& parent_index) const {
  * @throws std::out_of_range If the query index is out of range
  */
 template <typename X>
-bool tree<X>::is_last_child(const Tree_pos& self_index) const {
+inline bool tree<X>::is_last_child(const Tree_pos& self_index) const {
   I(_check_idx_exists(self_index), "is_last_child: Index out of range");
 
   const auto self_chunk_id     = (self_index >> CHUNK_SHIFT);
@@ -886,7 +932,7 @@ bool tree<X>::is_last_child(const Tree_pos& self_index) const {
  * @throws std::out_of_range If the query index is out of range
  */
 template <typename X>
-bool tree<X>::is_first_child(const Tree_pos& self_index) const {
+inline bool tree<X>::is_first_child(const Tree_pos& self_index) const {
   I(_check_idx_exists(self_index), "is_first_child: Index out of range");
 
   const auto self_chunk_id     = (self_index >> CHUNK_SHIFT);
@@ -910,7 +956,7 @@ bool tree<X>::is_first_child(const Tree_pos& self_index) const {
  * @throws std::out_of_range If the sibling index is out of range
  */
 template <typename X>
-Tree_pos tree<X>::get_sibling_next(const Tree_pos& sibling_id) const {
+inline Tree_pos tree<X>::get_sibling_next(const Tree_pos& sibling_id) const {
   I(_check_idx_exists(sibling_id), "get_sibling_next: Sibling index out of range");
 
   // If this is the last child, no next sibling
@@ -926,7 +972,9 @@ Tree_pos tree<X>::get_sibling_next(const Tree_pos& sibling_id) const {
   }
 
   // Just jump to the next sibling chunk, or returns invalid
-  return pointers_stack[curr_chunk_id].get_next_sibling() << CHUNK_SHIFT;  // default is INVALID
+  return pointers_stack[curr_chunk_id].get_next_sibling() == INVALID
+             ? INVALID
+             : static_cast<Tree_pos>(pointers_stack[curr_chunk_id].get_next_sibling() << CHUNK_SHIFT);
 }
 
 /**
@@ -940,7 +988,7 @@ Tree_pos tree<X>::get_sibling_next(const Tree_pos& sibling_id) const {
  *       happens if someone is deleted from the middle
  */
 template <typename X>
-Tree_pos tree<X>::get_sibling_prev(const Tree_pos& sibling_id) const {
+inline Tree_pos tree<X>::get_sibling_prev(const Tree_pos& sibling_id) const {
   I(_check_idx_exists(sibling_id), "get_sibling_prev: Sibling index out of range");
 
   // If this is the first child, no prev sibling
@@ -1074,10 +1122,10 @@ Tree_pos tree<X>::add_root(const X& data) {
   // Add the single pointer node for all CHUNK_SIZE entries
   pointers_stack.emplace_back();
 
-  // Set num occupied to 1
-  // pointers_stack[ROOT].set_num_short_del_occ(0);
+  // set num occupied to 0
+  pointers_stack[ROOT >> CHUNK_SHIFT].set_num_short_del_occ(0);
 
-  return (data_stack.size() - CHUNK_SIZE);
+  return ROOT;
 }
 
 /**
@@ -1109,6 +1157,9 @@ Tree_pos tree<X>::add_child(const Tree_pos& parent_index, const X& data) {
 
   // Set num occupied to 0
   pointers_stack[child_chunk_id].set_num_short_del_occ(0);
+
+  // update is_leaf flag
+  pointers_stack[parent_index >> CHUNK_SHIFT].set_is_leaf(false);
 
   return child_chunk_id << CHUNK_SHIFT;
 }
@@ -1194,6 +1245,11 @@ void tree<X>::delete_leaf(const Tree_pos& leaf_index) {
     const auto parent_index = pointers_stack[leaf_chunk_id].get_parent();
     const auto new_par_id   = _try_fit_child_ptr(parent_index, prev_sibling_id);
     pointers_stack[leaf_chunk_id].set_parent(new_par_id);
+
+    // check if parent has no more children
+    if (get_first_child(parent_index) == INVALID) {
+      pointers_stack[parent_index >> CHUNK_SHIFT].set_is_leaf(true);
+    }
   }
 }
 
@@ -1223,14 +1279,14 @@ void tree<X>::delete_subtree(const Tree_pos& subtree_root) {
     q.pop();
     nodes_to_delete.push_back(node);
 
-    for (auto child = get_first_child(node); child != INVALID; child = get_next_sibling(child)) {
+    for (auto child = get_first_child(node); child != INVALID; child = get_sibling_next(child)) {
       q.push(child);
     }
   }
 
   // Delete nodes in reverse order to ensure leaves are deleted first
   for (auto it = nodes_to_delete.rbegin(); it != nodes_to_delete.rend(); ++it) {
-    if (get_first_child(*it) == INVALID) {
+    if (is_leaf(*it)) {
       delete_leaf(*it);
     }
   }


### PR DESCRIPTION
### Major changes:
- Added an is_leaf flag, which quickly checks if a node is leaf without calling get_first_child (since most of the runtime is stuck on it).
- Adjusted bit allocations to fit the is_leaf flag without exceeding the limit (CHUNK_BITS: 50 -> 49, SHORT_DELTA: 18 -> 17).
-  Optimized pre-order traversal and const_pre_order_interator by replacing calls to get_first_child with checks to is_leaf.
- In methods that add children, set is_leaf to false for the parent node, in delete_leaf, check if the parent node becomes a leaf after deletion and update is_leaf if so, in delete_subtree, use is_leaf in the deletion process.
### Minor changes:
- Marked functions as inline to suggest inlining to the compiler.
- Minor changes to relevant methods to maintain is_leaf correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `is_leaf` flag in the tree structure to better manage leaf nodes.
	- Added getter and setter methods for the `is_leaf` attribute.

- **Improvements**
	- Enhanced traversal methods to accurately handle leaf nodes.
	- Optimized performance with inline functions for various tree operations.

- **Bug Fixes**
	- Adjusted logic for updating the `is_leaf` flag when children are added or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->