### PR TITLE
Add HHDS graph/tree attribute system with persistence and tests

### DIFF
--- a/hhds/BUILD.bazel
+++ b/hhds/BUILD.bazel
@@ -39,9 +39,11 @@ cc_library(
         exclude = ["*test*.cpp"],
     ),
     hdrs = glob([
+        "attr.hpp",
         "tree.hpp",
         "tree_print.hpp",
         "graph_sizing.hpp",
+        "attrs/name.hpp",
     ]),
     copts = COPTS,
     defines = select({
@@ -67,6 +69,8 @@ cc_library(
     name = "graph",
     srcs = ["graph.cpp"],
     hdrs = [
+        "attr.hpp",
+        "attrs/name.hpp",
         "graph.hpp",
         "graph_sizing.hpp",
         "hash_set3.hpp",

--- a/hhds/attr.hpp
+++ b/hhds/attr.hpp
@@ -1,0 +1,494 @@
+#pragma once
+
+#include <cassert>
+#include <cstdint>
+#include <functional>
+#include <istream>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <typeindex>
+#include <unordered_map>
+#include <utility>
+
+#include "hhds/graph_sizing.hpp"
+
+namespace hhds {
+
+struct flat_storage {};
+struct hier_storage {};
+
+template <class Tag>
+concept Attribute = requires {
+  typename Tag::value_type;
+  typename Tag::storage;
+  requires std::is_same_v<typename Tag::storage, flat_storage> || std::is_same_v<typename Tag::storage, hier_storage>;
+};
+
+template <Attribute Tag>
+using attr_result_t = std::conditional_t<
+    std::is_trivially_copyable_v<typename Tag::value_type> && sizeof(typename Tag::value_type) <= 16,
+    typename Tag::value_type,
+    const typename Tag::value_type&>;
+
+using Attr_key = uint64_t;
+
+struct Hier_attr_key {
+  int64_t  hier_pos = 0;
+  Attr_key flat_key = 0;
+
+  [[nodiscard]] bool operator==(const Hier_attr_key& other) const noexcept {
+    return hier_pos == other.hier_pos && flat_key == other.flat_key;
+  }
+};
+
+struct Hier_attr_key_hash {
+  [[nodiscard]] size_t operator()(const Hier_attr_key& key) const noexcept {
+    const size_t h1 = std::hash<int64_t>{}(key.hier_pos);
+    const size_t h2 = std::hash<Attr_key>{}(key.flat_key);
+    return h1 ^ (h2 + 0x9e3779b97f4a7c15ULL + (h1 << 6U) + (h1 >> 2U));
+  }
+};
+
+[[nodiscard]] constexpr Attr_key make_node_attr_key(uint64_t raw_id) noexcept { return (raw_id << 1U) | 0U; }
+[[nodiscard]] constexpr Attr_key make_pin_attr_key(uint64_t raw_id) noexcept { return (raw_id << 1U) | 1U; }
+
+enum class Attr_storage_kind : uint8_t { Flat = 0, Hier = 1 };
+
+template <Attribute Tag>
+[[nodiscard]] constexpr Attr_storage_kind attr_storage_kind() noexcept {
+  if constexpr (std::is_same_v<typename Tag::storage, flat_storage>) {
+    return Attr_storage_kind::Flat;
+  } else {
+    return Attr_storage_kind::Hier;
+  }
+}
+
+template <Attribute Tag>
+[[nodiscard]] inline std::string attr_tag_name() {
+  return typeid(Tag).name();
+}
+
+template <typename T>
+struct dependent_false : std::false_type {};
+
+namespace detail {
+
+class Attr_store_base;
+
+struct Attr_tag_registry_entry {
+  std::type_index                                           type_key{typeid(void)};
+  Attr_storage_kind                                         storage_kind = Attr_storage_kind::Flat;
+  std::string                                               persistent_id;
+  std::function<std::unique_ptr<Attr_store_base>()>         factory;
+};
+
+class Attr_tag_registry {
+public:
+  [[nodiscard]] static Attr_tag_registry& instance() {
+    static Attr_tag_registry registry;
+    return registry;
+  }
+
+  template <Attribute Tag>
+  const Attr_tag_registry_entry& register_tag(std::string_view persistent_id);
+
+  template <Attribute Tag>
+  const Attr_tag_registry_entry& ensure_tag() {
+    const auto type_key = std::type_index(typeid(Tag));
+    const auto it       = by_type_.find(type_key);
+    if (it != by_type_.end()) {
+      return it->second;
+    }
+    return register_tag<Tag>(attr_tag_name<Tag>());
+  }
+
+  [[nodiscard]] const Attr_tag_registry_entry* find(std::string_view persistent_id) const {
+    const auto it = by_id_.find(std::string(persistent_id));
+    if (it == by_id_.end()) {
+      return nullptr;
+    }
+    const auto type_it = by_type_.find(it->second);
+    return type_it == by_type_.end() ? nullptr : &type_it->second;
+  }
+
+private:
+  std::unordered_map<std::type_index, Attr_tag_registry_entry> by_type_;
+  std::unordered_map<std::string, std::type_index>             by_id_;
+};
+
+template <typename T>
+void write_value(std::ostream& os, const T& value) {
+  if constexpr (std::is_same_v<T, std::string>) {
+    const uint64_t size = value.size();
+    os.write(reinterpret_cast<const char*>(&size), sizeof(size));
+    if (size != 0) {
+      os.write(value.data(), static_cast<std::streamsize>(size));
+    }
+  } else if constexpr (std::is_trivially_copyable_v<T>) {
+    os.write(reinterpret_cast<const char*>(&value), sizeof(value));
+  } else {
+    static_assert(dependent_false<T>::value, "Attribute persistence supports only std::string and trivially copyable values");
+  }
+}
+
+template <typename T>
+T read_value(std::istream& is) {
+  if constexpr (std::is_same_v<T, std::string>) {
+    uint64_t size = 0;
+    is.read(reinterpret_cast<char*>(&size), sizeof(size));
+    std::string value(size, '\0');
+    if (size != 0) {
+      is.read(value.data(), static_cast<std::streamsize>(size));
+    }
+    return value;
+  } else if constexpr (std::is_trivially_copyable_v<T>) {
+    T value{};
+    is.read(reinterpret_cast<char*>(&value), sizeof(value));
+    return value;
+  } else {
+    static_assert(dependent_false<T>::value, "Attribute persistence supports only std::string and trivially copyable values");
+  }
+}
+
+class Attr_store_base {
+public:
+  virtual ~Attr_store_base() = default;
+
+  [[nodiscard]] virtual Attr_storage_kind storage_kind() const noexcept = 0;
+  [[nodiscard]] virtual std::type_index   type_key() const noexcept     = 0;
+  [[nodiscard]] virtual std::string_view  persistent_id() const noexcept = 0;
+  [[nodiscard]] virtual bool              empty() const noexcept         = 0;
+  [[nodiscard]] virtual uint64_t          size() const noexcept          = 0;
+  virtual void                            clear_entries() noexcept       = 0;
+  virtual void                            erase_object(Attr_key key) noexcept = 0;
+  virtual void                            save_entries(std::ostream& os) const = 0;
+  virtual void                            load_entries(std::istream& is, uint64_t count) = 0;
+};
+
+template <Attribute Tag>
+using attr_map_t = std::conditional_t<
+    std::is_same_v<typename Tag::storage, flat_storage>,
+    std::unordered_map<Attr_key, typename Tag::value_type>,
+    std::unordered_map<Hier_attr_key, typename Tag::value_type, Hier_attr_key_hash>>;
+
+template <Attribute Tag>
+class Attr_store_impl final : public Attr_store_base {
+public:
+  using map_type   = attr_map_t<Tag>;
+  using value_type = typename Tag::value_type;
+
+  explicit Attr_store_impl(std::string persistent_id) : persistent_id_(std::move(persistent_id)) {}
+
+  [[nodiscard]] Attr_storage_kind storage_kind() const noexcept override { return attr_storage_kind<Tag>(); }
+  [[nodiscard]] std::type_index   type_key() const noexcept override { return std::type_index(typeid(Tag)); }
+  [[nodiscard]] std::string_view  persistent_id() const noexcept override { return persistent_id_; }
+  [[nodiscard]] bool              empty() const noexcept override { return map_.empty(); }
+  [[nodiscard]] uint64_t          size() const noexcept override { return static_cast<uint64_t>(map_.size()); }
+  void                            clear_entries() noexcept override { map_.clear(); }
+
+  void erase_object(Attr_key key) noexcept override {
+    if constexpr (std::is_same_v<typename Tag::storage, flat_storage>) {
+      map_.erase(key);
+    } else {
+      for (auto it = map_.begin(); it != map_.end();) {
+        if (it->first.flat_key == key) {
+          it = map_.erase(it);
+        } else {
+          ++it;
+        }
+      }
+    }
+  }
+
+  void save_entries(std::ostream& os) const override {
+    if constexpr (std::is_same_v<typename Tag::storage, flat_storage>) {
+      for (const auto& [key, value] : map_) {
+        os.write(reinterpret_cast<const char*>(&key), sizeof(key));
+        write_value<value_type>(os, value);
+      }
+    } else {
+      for (const auto& [key, value] : map_) {
+        os.write(reinterpret_cast<const char*>(&key.hier_pos), sizeof(key.hier_pos));
+        os.write(reinterpret_cast<const char*>(&key.flat_key), sizeof(key.flat_key));
+        write_value<value_type>(os, value);
+      }
+    }
+  }
+
+  void load_entries(std::istream& is, uint64_t count) override {
+    map_.clear();
+    for (uint64_t i = 0; i < count; ++i) {
+      if constexpr (std::is_same_v<typename Tag::storage, flat_storage>) {
+        Attr_key key = 0;
+        is.read(reinterpret_cast<char*>(&key), sizeof(key));
+        map_.emplace(key, read_value<value_type>(is));
+      } else {
+        Hier_attr_key key{};
+        is.read(reinterpret_cast<char*>(&key.hier_pos), sizeof(key.hier_pos));
+        is.read(reinterpret_cast<char*>(&key.flat_key), sizeof(key.flat_key));
+        map_.emplace(key, read_value<value_type>(is));
+      }
+    }
+  }
+
+  [[nodiscard]] map_type&       map() noexcept { return map_; }
+  [[nodiscard]] const map_type& map() const noexcept { return map_; }
+
+private:
+  std::string persistent_id_;
+  map_type    map_;
+};
+
+template <Attribute Tag>
+const Attr_tag_registry_entry& Attr_tag_registry::register_tag(std::string_view persistent_id) {
+  const auto type_key = std::type_index(typeid(Tag));
+  const auto type_it  = by_type_.find(type_key);
+  if (type_it != by_type_.end()) {
+    if (!persistent_id.empty()) {
+      if (type_it->second.persistent_id != persistent_id) {
+        const std::string default_id = attr_tag_name<Tag>();
+        assert(type_it->second.persistent_id == default_id
+               && "register_tag: conflicting persistent ids for attribute tag");
+
+        const auto current_id_it = by_id_.find(type_it->second.persistent_id);
+        if (current_id_it != by_id_.end() && current_id_it->second == type_key) {
+          by_id_.erase(current_id_it);
+        }
+
+        const auto new_id_it = by_id_.find(std::string(persistent_id));
+        assert((new_id_it == by_id_.end() || new_id_it->second == type_key)
+               && "register_tag: persistent id already registered for another attribute tag");
+
+        type_it->second.persistent_id = std::string(persistent_id);
+        type_it->second.factory       = [id = type_it->second.persistent_id]() { return std::make_unique<Attr_store_impl<Tag>>(id); };
+        by_id_.emplace(type_it->second.persistent_id, type_key);
+      }
+    }
+    return type_it->second;
+  }
+
+  const std::string id = persistent_id.empty() ? attr_tag_name<Tag>() : std::string(persistent_id);
+  const auto        id_it = by_id_.find(id);
+  assert(id_it == by_id_.end() && "register_tag: persistent id already registered for another attribute tag");
+
+  Attr_tag_registry_entry entry;
+  entry.type_key      = type_key;
+  entry.storage_kind  = attr_storage_kind<Tag>();
+  entry.persistent_id = id;
+  entry.factory       = [id]() { return std::make_unique<Attr_store_impl<Tag>>(id); };
+
+  by_id_.emplace(entry.persistent_id, type_key);
+  auto [it, inserted] = by_type_.emplace(type_key, std::move(entry));
+  assert(inserted && "register_tag: failed to insert attribute registry entry");
+  return it->second;
+}
+
+}  // namespace detail
+
+template <Attribute Tag>
+inline void register_attr_tag(std::string_view persistent_id) {
+  (void)detail::Attr_tag_registry::instance().register_tag<Tag>(persistent_id);
+}
+
+class Attr_host;
+
+template <Attribute Tag>
+class AttrRef {
+public:
+  using value_type = typename Tag::value_type;
+
+  AttrRef() = default;
+  AttrRef(Attr_host* host, Attr_key flat_key) : host_(host), flat_key_(flat_key) {}
+  AttrRef(Attr_host* host, Attr_key flat_key, int64_t hier_pos) : host_(host), flat_key_(flat_key), hier_pos_(hier_pos), has_hier_(true) {}
+
+  [[nodiscard]] bool has() const;
+  [[nodiscard]] attr_result_t<Tag> get() const;
+  void                            set(const value_type& value);
+  void                            set(value_type&& value);
+  void                            del();
+
+private:
+  [[nodiscard]] auto key() const;
+
+  Attr_host* host_      = nullptr;
+  Attr_key   flat_key_  = 0;
+  int64_t    hier_pos_  = 0;
+  bool       has_hier_  = false;
+};
+
+class Attr_host {
+public:
+  virtual ~Attr_host() = default;
+
+  template <Attribute Tag>
+  auto& attr_store(Tag = {}) {
+    const auto& desc = detail::Attr_tag_registry::instance().ensure_tag<Tag>();
+    const auto  key  = std::type_index(typeid(Tag));
+    auto        it   = attr_stores_.find(key);
+    if (it == attr_stores_.end()) {
+      auto [new_it, inserted] = attr_stores_.emplace(key, desc.factory());
+      assert(inserted && "attr_store: failed to create store");
+      it = new_it;
+    }
+    auto* typed = static_cast<detail::Attr_store_impl<Tag>*>(it->second.get());
+    return typed->map();
+  }
+
+  template <Attribute Tag>
+  [[nodiscard]] const auto* find_attr_store(Tag = {}) const {
+    const auto it = attr_stores_.find(std::type_index(typeid(Tag)));
+    if (it == attr_stores_.end()) {
+      return static_cast<const typename detail::Attr_store_impl<Tag>::map_type*>(nullptr);
+    }
+    const auto* typed = static_cast<const detail::Attr_store_impl<Tag>*>(it->second.get());
+    return &typed->map();
+  }
+
+  template <Attribute Tag>
+  void attr_clear(Tag = {}) {
+    auto& store = attr_store(Tag{});
+    store.clear();
+    attr_note_modified();
+  }
+
+  template <Attribute Tag>
+  [[nodiscard]] bool has_attr(Tag = {}) const {
+    return attr_stores_.find(std::type_index(typeid(Tag))) != attr_stores_.end();
+  }
+
+protected:
+  void erase_attr_object(Attr_key key) noexcept {
+    for (auto& [_, store] : attr_stores_) {
+      store->erase_object(key);
+    }
+  }
+
+  void discard_attr_stores() noexcept { attr_stores_.clear(); }
+
+  void save_attr_stores(std::ostream& os) const {
+    uint64_t store_count = 0;
+    for (const auto& [_, store] : attr_stores_) {
+      if (!store->empty()) {
+        ++store_count;
+      }
+    }
+
+    os.write(reinterpret_cast<const char*>(&store_count), sizeof(store_count));
+    for (const auto& [_, store] : attr_stores_) {
+      if (store->empty()) {
+        continue;
+      }
+
+      const auto id_size = static_cast<uint64_t>(store->persistent_id().size());
+      os.write(reinterpret_cast<const char*>(&id_size), sizeof(id_size));
+      os.write(store->persistent_id().data(), static_cast<std::streamsize>(id_size));
+
+      const auto storage_kind = static_cast<uint8_t>(store->storage_kind());
+      os.write(reinterpret_cast<const char*>(&storage_kind), sizeof(storage_kind));
+
+      const auto entry_count = store->size();
+      os.write(reinterpret_cast<const char*>(&entry_count), sizeof(entry_count));
+      store->save_entries(os);
+    }
+  }
+
+  void load_attr_stores(std::istream& is) {
+    discard_attr_stores();
+
+    uint64_t store_count = 0;
+    is.read(reinterpret_cast<char*>(&store_count), sizeof(store_count));
+    for (uint64_t i = 0; i < store_count; ++i) {
+      uint64_t id_size = 0;
+      is.read(reinterpret_cast<char*>(&id_size), sizeof(id_size));
+      std::string persistent_id(id_size, '\0');
+      if (id_size != 0) {
+        is.read(persistent_id.data(), static_cast<std::streamsize>(id_size));
+      }
+
+      uint8_t storage_kind_u8 = 0;
+      is.read(reinterpret_cast<char*>(&storage_kind_u8), sizeof(storage_kind_u8));
+      const auto storage_kind = static_cast<Attr_storage_kind>(storage_kind_u8);
+
+      uint64_t entry_count = 0;
+      is.read(reinterpret_cast<char*>(&entry_count), sizeof(entry_count));
+
+      const auto* desc = detail::Attr_tag_registry::instance().find(persistent_id);
+      assert(desc != nullptr && "load_attr_stores: attribute tag was not registered for deserialization");
+      assert(desc->storage_kind == storage_kind && "load_attr_stores: persisted attribute storage kind mismatch");
+
+      auto store = desc->factory();
+      store->load_entries(is, entry_count);
+      attr_stores_[desc->type_key] = std::move(store);
+    }
+  }
+
+private:
+  virtual void attr_note_modified() noexcept = 0;
+
+  std::unordered_map<std::type_index, std::unique_ptr<detail::Attr_store_base>> attr_stores_;
+
+  template <Attribute Tag>
+  friend class AttrRef;
+};
+
+template <Attribute Tag>
+inline auto AttrRef<Tag>::key() const {
+  assert(host_ != nullptr && "AttrRef: no attribute host");
+  if constexpr (std::is_same_v<typename Tag::storage, flat_storage>) {
+    return flat_key_;
+  } else {
+    assert(has_hier_ && "AttrRef: hier attribute requires hierarchy context");
+    return Hier_attr_key{hier_pos_, flat_key_};
+  }
+}
+
+template <Attribute Tag>
+inline bool AttrRef<Tag>::has() const {
+  const auto* map = host_ != nullptr ? host_->find_attr_store(Tag{}) : nullptr;
+  if (map == nullptr) {
+    if constexpr (std::is_same_v<typename Tag::storage, hier_storage>) {
+      assert(has_hier_ && "AttrRef::has: hier attribute requires hierarchy context");
+    }
+    return false;
+  }
+  return map->find(key()) != map->end();
+}
+
+template <Attribute Tag>
+inline attr_result_t<Tag> AttrRef<Tag>::get() const {
+  const auto* map = host_ != nullptr ? host_->find_attr_store(Tag{}) : nullptr;
+  assert(map != nullptr && "AttrRef::get: attribute store is not registered");
+  const auto it = map->find(key());
+  assert(it != map->end() && "AttrRef::get: attribute value is not set");
+  if constexpr (std::is_same_v<attr_result_t<Tag>, typename Tag::value_type>) {
+    return it->second;
+  } else {
+    return it->second;
+  }
+}
+
+template <Attribute Tag>
+inline void AttrRef<Tag>::set(const value_type& value) {
+  auto& map = host_->attr_store(Tag{});
+  map[key()] = value;
+  host_->attr_note_modified();
+}
+
+template <Attribute Tag>
+inline void AttrRef<Tag>::set(value_type&& value) {
+  auto& map = host_->attr_store(Tag{});
+  map[key()] = std::move(value);
+  host_->attr_note_modified();
+}
+
+template <Attribute Tag>
+inline void AttrRef<Tag>::del() {
+  auto& map = host_->attr_store(Tag{});
+  map.erase(key());
+  host_->attr_note_modified();
+}
+
+}  // namespace hhds

--- a/hhds/attrs/name.hpp
+++ b/hhds/attrs/name.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+
+#include "hhds/attr.hpp"
+
+namespace hhds::attrs {
+
+struct name_t {
+  using value_type = std::string;
+  using storage    = hhds::flat_storage;
+};
+
+inline constexpr name_t name{};
+
+}  // namespace hhds::attrs
+
+namespace hhds {
+
+template <>
+[[nodiscard]] inline std::string attr_tag_name<attrs::name_t>() {
+  return "hhds::attrs::name";
+}
+
+}  // namespace hhds

--- a/hhds/graph.cpp
+++ b/hhds/graph.cpp
@@ -730,7 +730,10 @@ auto NodeEntry::get_edges(Nid nid, const OverflowVec& overflow) const noexcept -
   return EdgeRange(this, nid, overflow);
 }
 
-Graph::Graph() { clear_graph(); }
+Graph::Graph() {
+  register_attr_tag<attrs::name_t>("hhds::attrs::name");
+  clear_graph();
+}
 
 void Graph::assert_accessible() const noexcept { assert(!deleted_ && "graph is no longer valid"); }
 
@@ -789,6 +792,7 @@ void Graph::invalidate_from_library() noexcept {
     return;
   }
   release_storage();
+  discard_attr_stores();
   deleted_   = true;
   owner_lib_ = nullptr;
   node_table.clear();
@@ -813,6 +817,7 @@ void Graph::invalidate_from_library() noexcept {
 void Graph::clear_graph() {
   assert_accessible();
   release_storage();
+  discard_attr_stores();
   node_table.clear();
   pin_table.clear();
   input_pins_.clear();
@@ -830,6 +835,7 @@ void Graph::clear() {
 
   overflow_sets_.clear();
   overflow_free_.clear();
+  discard_attr_stores();
 
   for (auto& pin : pin_table) {
     pin = PinEntry();
@@ -1607,6 +1613,7 @@ void Graph::delete_pin(Pid pin_pid) {
     overflow_free_.push_back(pin->get_overflow_idx());
     overflow_sets_[pin->get_overflow_idx()].clear();
   }
+  erase_attr_object(make_pin_attr_key(static_cast<uint64_t>(pin_lookup)));
   pin_table[actual_id] = PinEntry();
   invalidate_traversal_caches();
 }
@@ -2314,6 +2321,8 @@ void Graph::delete_node(Nid nid) {
     del_edge_int(driver, sink);
   }
 
+  erase_attr_object(make_node_attr_key(static_cast<uint64_t>(nid)));
+  erase_attr_object(make_pin_attr_key(static_cast<uint64_t>(nid)));
   for (auto pin_pid : pins_to_delete) {
     const Pid actual_pin_id = pin_pid >> 2;
     auto*     pin           = &pin_table[actual_pin_id];
@@ -2321,6 +2330,7 @@ void Graph::delete_node(Nid nid) {
       overflow_free_.push_back(pin->get_overflow_idx());
       overflow_sets_[pin->get_overflow_idx()].clear();
     }
+    erase_attr_object(make_pin_attr_key(static_cast<uint64_t>(pin_pid)));
     pin_table[actual_pin_id] = PinEntry();
   }
 
@@ -2412,12 +2422,58 @@ void Graph::display_next_pin_of_node() const {
   }
 }
 
+void Graph::print(std::ostream& os) const {
+  assert_accessible();
+  os << name_ << " {\n";
+  for (auto node : forward_class()) {
+    const Nid raw_nid = node.get_raw_nid() & ~static_cast<Nid>(3);
+    const Nid actual  = raw_nid >> 2;
+    if (actual < 4) {
+      continue;
+    }
+
+    os << "  %" << raw_nid << " = ";
+    if (node.attr(attrs::name).has()) {
+      os << node.attr(attrs::name).get();
+    } else {
+      os << "node_" << actual;
+    }
+
+    const auto* entry = ref_node(raw_nid);
+    if (entry->has_subnode() && owner_lib_ != nullptr) {
+      const auto gio = owner_lib_->graph_ios_[static_cast<size_t>(entry->get_subnode())];
+      if (gio != nullptr) {
+        os << " : " << gio->get_name();
+      }
+    }
+    os << '\n';
+
+    for (Pid cur_pin = entry->get_next_pin_id(); cur_pin != 0;) {
+      const Pid canonical_pin = (cur_pin & ~static_cast<Pid>(2)) | static_cast<Pid>(1);
+      const auto pin          = make_pin_class(canonical_pin);
+      os << "    ." << pin.get_pin_name();
+      if (pin.attr(attrs::name).has()) {
+        os << " @" << pin.attr(attrs::name).get();
+      }
+      os << '\n';
+      cur_pin = ref_pin(canonical_pin)->get_next_pin_id();
+    }
+  }
+  os << "}\n";
+}
+
+std::string Graph::print() const {
+  std::ostringstream oss;
+  print(oss);
+  return oss.str();
+}
+
 // --------------------------------------------------------------------------
 // Binary persistence
 // --------------------------------------------------------------------------
 
 static constexpr uint32_t GRAPH_BODY_MAGIC   = 0x48484742;  // "HHGB"
-static constexpr uint32_t GRAPH_BODY_VERSION = 1;
+static constexpr uint32_t GRAPH_BODY_VERSION = 2;
 static constexpr uint32_t ENDIAN_CHECK       = 0x01020304;
 
 void Graph::save_body(const std::string& dir_path) const {
@@ -2444,6 +2500,7 @@ void Graph::save_body(const std::string& dir_path) const {
     // Bulk write node_table and pin_table — pointer-free POD arrays.
     ofs.write(reinterpret_cast<const char*>(node_table.data()), static_cast<std::streamsize>(node_count * sizeof(NodeEntry)));
     ofs.write(reinterpret_cast<const char*>(pin_table.data()), static_cast<std::streamsize>(pin_count * sizeof(PinEntry)));
+    save_attr_stores(ofs);
   }
 
   // --- overflow_<idx>.bin (one per overflow set) ---
@@ -2479,7 +2536,7 @@ void Graph::load_body(const std::string& dir_path) {
     ifs.read(reinterpret_cast<char*>(&version), sizeof(version));
     ifs.read(reinterpret_cast<char*>(&endian), sizeof(endian));
     assert(magic == GRAPH_BODY_MAGIC && "load_body: bad magic");
-    assert(version == GRAPH_BODY_VERSION && "load_body: unsupported version");
+    assert((version == 1 || version == GRAPH_BODY_VERSION) && "load_body: unsupported version");
     assert(endian == ENDIAN_CHECK && "load_body: endian mismatch — file from different platform");
 
     uint64_t node_count = 0, pin_count = 0, overflow_count = 0;
@@ -2496,6 +2553,13 @@ void Graph::load_body(const std::string& dir_path) {
 
     // Prepare overflow_sets_ vector.
     overflow_sets_.resize(overflow_count);
+    overflow_free_.clear();
+
+    if (version >= 2) {
+      load_attr_stores(ifs);
+    } else {
+      discard_attr_stores();
+    }
   }
 
   // --- overflow_<idx>.bin ---

--- a/hhds/graph.hpp
+++ b/hhds/graph.hpp
@@ -16,6 +16,8 @@
 #include <utility>
 #include <vector>
 
+#include "attr.hpp"
+#include "attrs/name.hpp"
 #include "graph_sizing.hpp"
 #include "tree.hpp"
 #include "unordered_dense.hpp"
@@ -225,6 +227,16 @@ public:
   [[nodiscard]] std::vector<Edge_class> out_edges() const;
   [[nodiscard]] std::vector<Edge_class> inp_edges() const;
 
+  template <Attribute Tag>
+  [[nodiscard]] AttrRef<Tag> attr(Tag = {}) const {
+    assert(graph_ != nullptr && "attr: pin is not attached to a graph");
+    const auto flat_key = make_pin_attr_key(static_cast<uint64_t>(pin_pid & ~static_cast<Pid>(2)));
+    if (context_ == Handle_context::Hier) {
+      return AttrRef<Tag>(graph_, flat_key, hier_pos_);
+    }
+    return AttrRef<Tag>(graph_, flat_key);
+  }
+
   // Interop with existing APIs that still accept raw Pid.
   [[nodiscard]] constexpr operator Pid() const noexcept { return pin_pid; }
 
@@ -310,6 +322,16 @@ public:
   [[nodiscard]] std::vector<Edge_class> inp_edges() const;
   [[nodiscard]] std::vector<Pin_class>  out_pins() const;
   [[nodiscard]] std::vector<Pin_class>  inp_pins() const;
+
+  template <Attribute Tag>
+  [[nodiscard]] AttrRef<Tag> attr(Tag = {}) const {
+    assert(graph_ != nullptr && "attr: node is not attached to a graph");
+    const auto flat_key = make_node_attr_key(static_cast<uint64_t>(raw_nid & ~static_cast<Nid>(3)));
+    if (context_ == Context::Hier) {
+      return AttrRef<Tag>(graph_, flat_key, hier_pos_);
+    }
+    return AttrRef<Tag>(graph_, flat_key);
+  }
 
   // Interop with existing APIs that still accept raw Nid.
   [[nodiscard]] constexpr operator Nid() const noexcept { return raw_nid; }
@@ -521,7 +543,7 @@ using Pin  = Pin_class;
 
 class GraphLibrary;
 
-class Graph {
+class Graph : public Attr_host {
 public:
   Graph();
   // Graphs are owned via handles; copying or moving would break library identity and traversal caches.
@@ -598,7 +620,11 @@ public:
   void save_body(const std::string& dir_path) const;
   void load_body(const std::string& dir_path);
 
+  void                      print(std::ostream& os) const;
+  [[nodiscard]] std::string print() const;
+
 private:
+  void               attr_note_modified() noexcept override { dirty_ = true; }
   [[nodiscard]] OverflowPool get_overflow_pool() { return {overflow_sets_, overflow_free_}; }
   void               assert_accessible() const noexcept;
   void               assert_node_exists(const Node_class& node) const noexcept;

--- a/hhds/tests/test_storage.cpp
+++ b/hhds/tests/test_storage.cpp
@@ -5,6 +5,28 @@
 #include "hhds/graph.hpp"
 #include "hhds/tree.hpp"
 
+namespace test_attrs {
+
+struct bits_t {
+  using value_type = int;
+  using storage    = hhds::flat_storage;
+};
+inline constexpr bits_t bits{};
+
+struct hbits_t {
+  using value_type = int;
+  using storage    = hhds::hier_storage;
+};
+inline constexpr hbits_t hbits{};
+
+struct loc_t {
+  using value_type = int;
+  using storage    = hhds::flat_storage;
+};
+inline constexpr loc_t loc{};
+
+}  // namespace test_attrs
+
 // ------------------------------------------------------------------
 // Compile-time size checks — these enforce the storage layout
 // documented in docs/storage_internals.md.
@@ -191,6 +213,115 @@ TEST(GraphStorage, SubnodeForcesOverflow) {
   EXPECT_TRUE(entry->has_subnode());
 }
 
+TEST(GraphAttrs, FlatGetSetHasDeleteOnNodeAndPin) {
+  hhds::GraphLibrary lib;
+  auto               gio   = lib.create_io("top");
+  auto               graph = gio->create_graph();
+
+  auto node = graph->create_node();
+  auto pin  = node.create_driver_pin(1);
+
+  node.attr(hhds::attrs::name).set("adder");
+  pin.attr(hhds::attrs::name).set("sum");
+  node.attr(test_attrs::bits).set(32);
+
+  EXPECT_TRUE(graph->has_attr(hhds::attrs::name));
+  EXPECT_TRUE(graph->has_attr(test_attrs::bits));
+  EXPECT_TRUE(node.attr(hhds::attrs::name).has());
+  EXPECT_TRUE(pin.attr(hhds::attrs::name).has());
+  EXPECT_EQ(node.attr(hhds::attrs::name).get(), "adder");
+  EXPECT_EQ(pin.attr(hhds::attrs::name).get(), "sum");
+  EXPECT_EQ(node.attr(test_attrs::bits).get(), 32);
+
+  pin.attr(hhds::attrs::name).del();
+  EXPECT_FALSE(pin.attr(hhds::attrs::name).has());
+  EXPECT_TRUE(node.attr(hhds::attrs::name).has());
+}
+
+TEST(GraphAttrs, PortZeroPinAttrsDoNotCollideWithNodeAttrs) {
+  hhds::GraphLibrary lib;
+  auto               gio   = lib.create_io("top");
+  auto               graph = gio->create_graph();
+
+  auto node = graph->create_node();
+  auto pin0 = node.create_driver_pin(0);
+
+  node.attr(hhds::attrs::name).set("node_name");
+  pin0.attr(hhds::attrs::name).set("pin0_name");
+
+  EXPECT_EQ(node.attr(hhds::attrs::name).get(), "node_name");
+  EXPECT_EQ(pin0.attr(hhds::attrs::name).get(), "pin0_name");
+  EXPECT_EQ(node.create_sink_pin(0).attr(hhds::attrs::name).get(), "pin0_name");
+}
+
+TEST(GraphAttrs, DeleteNodeRemovesNodeAndPinAttrs) {
+  hhds::GraphLibrary lib;
+  auto               gio   = lib.create_io("top");
+  auto               graph = gio->create_graph();
+
+  auto node = graph->create_node();
+  auto pin0 = node.create_driver_pin(0);
+  auto pin1 = node.create_driver_pin(1);
+
+  node.attr(hhds::attrs::name).set("node");
+  pin0.attr(hhds::attrs::name).set("pin0");
+  pin1.attr(hhds::attrs::name).set("pin1");
+
+  EXPECT_EQ(graph->attr_store(hhds::attrs::name).size(), 3u);
+
+  node.del_node();
+
+  EXPECT_EQ(graph->attr_store(hhds::attrs::name).size(), 0u);
+}
+
+TEST(GraphAttrs, AttrClearKeepsRegistrationAndClearDropsIt) {
+  hhds::GraphLibrary lib;
+  auto               gio   = lib.create_io("top");
+  auto               graph = gio->create_graph();
+
+  auto node = graph->create_node();
+  node.attr(test_attrs::bits).set(64);
+
+  graph->attr_clear(test_attrs::bits);
+  EXPECT_TRUE(graph->has_attr(test_attrs::bits));
+  EXPECT_FALSE(node.attr(test_attrs::bits).has());
+
+  graph->clear();
+  EXPECT_FALSE(graph->has_attr(test_attrs::bits));
+}
+
+TEST(GraphAttrs, HierAttrUsesHierarchyContext) {
+  hhds::GraphLibrary lib;
+
+  auto leaf_io = lib.create_io("leaf");
+  auto leaf    = leaf_io->create_graph();
+  auto leaf_n  = leaf->create_node();
+
+  auto top_io = lib.create_io("top");
+  auto top    = top_io->create_graph();
+  auto inst1  = top->create_node();
+  auto inst2  = top->create_node();
+  inst1.set_subnode(leaf_io);
+  inst2.set_subnode(leaf_io);
+
+  std::vector<hhds::Node_class> leaf_instances;
+  for (auto node : top->forward_hier()) {
+    if (node.get_current_gid() == leaf->get_gid() && node.get_raw_nid() == leaf_n.get_raw_nid()) {
+      leaf_instances.push_back(node);
+    }
+  }
+
+  ASSERT_EQ(leaf_instances.size(), 2u);
+
+  leaf_instances[0].attr(hhds::attrs::name).set("leaf_internal");
+  leaf_instances[0].attr(test_attrs::hbits).set(11);
+  leaf_instances[1].attr(test_attrs::hbits).set(22);
+
+  EXPECT_EQ(leaf_instances[1].attr(hhds::attrs::name).get(), "leaf_internal");
+  EXPECT_EQ(leaf_instances[0].attr(test_attrs::hbits).get(), 11);
+  EXPECT_EQ(leaf_instances[1].attr(test_attrs::hbits).get(), 22);
+}
+
 // ------------------------------------------------------------------
 // Tree storage tests
 // ------------------------------------------------------------------
@@ -297,6 +428,30 @@ TEST(TreeStorage, DeleteSubtreeAndClearTombstones) {
   EXPECT_FALSE(tio->has_tree());
 }
 
+TEST(TreeAttrs, FlatGetSetDeleteAndClear) {
+  auto forest = hhds::Forest::create();
+  auto tio    = forest->create_io("t");
+  auto tree   = tio->create_tree();
+
+  auto root  = tree->add_root_node();
+  auto child = root.add_child();
+
+  root.attr(hhds::attrs::name).set("program");
+  child.attr(test_attrs::loc).set(10);
+
+  EXPECT_TRUE(tree->has_attr(hhds::attrs::name));
+  EXPECT_TRUE(tree->has_attr(test_attrs::loc));
+  EXPECT_EQ(root.attr(hhds::attrs::name).get(), "program");
+  EXPECT_EQ(child.attr(test_attrs::loc).get(), 10);
+
+  child.del_node();
+  EXPECT_EQ(tree->attr_store(test_attrs::loc).size(), 0u);
+
+  tree->clear();
+  EXPECT_FALSE(tree->has_attr(hhds::attrs::name));
+  EXPECT_FALSE(tree->has_attr(test_attrs::loc));
+}
+
 // ------------------------------------------------------------------
 // Binary save/load round-trip tests
 // ------------------------------------------------------------------
@@ -305,6 +460,8 @@ TEST(GraphPersistence, SaveLoadRoundTrip) {
   namespace fs = std::filesystem;
   const std::string test_dir = "/tmp/hhds_test_graph_persist";
   fs::remove_all(test_dir);
+
+  hhds::register_attr_tag<test_attrs::bits_t>("test_attrs::bits");
 
   hhds::GraphLibrary lib;
   auto               top_gio = lib.create_io("top");
@@ -320,10 +477,14 @@ TEST(GraphPersistence, SaveLoadRoundTrip) {
   auto n2 = graph->create_node();
   auto n3 = graph->create_node();
   n1.set_subnode(sub_gio);
+  n1.attr(hhds::attrs::name).set("adder");
+  n2.attr(test_attrs::bits).set(32);
 
   auto drv = n1.create_driver_pin(0);
   auto snk = n2.create_sink_pin(0);
   drv.connect_sink(snk);
+  auto wide_pin = n3.create_driver_pin(1);
+  wide_pin.attr(test_attrs::bits).set(7);
 
   // Also connect n2 -> n3 to have multiple edges.
   auto drv2 = n2.create_driver_pin(0);
@@ -348,6 +509,7 @@ TEST(GraphPersistence, SaveLoadRoundTrip) {
   // Verify round-trip: same node count, same edges.
   auto loaded_n1 = hhds::Node_class(graph2.get(), n1.get_raw_nid());
   auto loaded_n2 = hhds::Node_class(graph2.get(), n2.get_raw_nid());
+  auto loaded_n3 = hhds::Node_class(graph2.get(), n3.get_raw_nid());
 
   auto loaded_out_n1 = graph2->out_edges(loaded_n1);
   auto loaded_out_n2 = graph2->out_edges(loaded_n2);
@@ -358,6 +520,9 @@ TEST(GraphPersistence, SaveLoadRoundTrip) {
   auto* entry = graph2->ref_node(n1.get_raw_nid());
   EXPECT_TRUE(entry->has_subnode());
   EXPECT_EQ(entry->get_subnode(), sub_gio->get_gid());
+  EXPECT_EQ(loaded_n1.attr(hhds::attrs::name).get(), "adder");
+  EXPECT_EQ(loaded_n2.attr(test_attrs::bits).get(), 32);
+  EXPECT_EQ(loaded_n3.get_driver_pin(1).attr(test_attrs::bits).get(), 7);
 
   fs::remove_all(test_dir);
 }
@@ -407,6 +572,8 @@ TEST(TreePersistence, SaveLoadRoundTrip) {
   const std::string test_dir = "/tmp/hhds_test_tree_persist";
   fs::remove_all(test_dir);
 
+  hhds::register_attr_tag<test_attrs::loc_t>("test_attrs::loc");
+
   auto forest = hhds::Forest::create();
   auto tio    = forest->create_io("t");
   auto tree   = tio->create_tree();
@@ -420,6 +587,8 @@ TEST(TreePersistence, SaveLoadRoundTrip) {
   c1.set_type(20);
   c2.set_type(30);
   gc1.set_type(40);
+  root.attr(hhds::attrs::name).set("program");
+  gc1.attr(test_attrs::loc).set(99);
 
   tree->save_body(test_dir);
   EXPECT_TRUE(fs::exists(fs::path(test_dir) / "body.bin"));
@@ -434,6 +603,8 @@ TEST(TreePersistence, SaveLoadRoundTrip) {
   EXPECT_EQ(tree2->get_type(c1.get_current_pos()), 20);
   EXPECT_EQ(tree2->get_type(c2.get_current_pos()), 30);
   EXPECT_EQ(tree2->get_type(gc1.get_current_pos()), 40);
+  EXPECT_EQ(tree2->as_class(root.get_current_pos()).attr(hhds::attrs::name).get(), "program");
+  EXPECT_EQ(tree2->as_class(gc1.get_current_pos()).attr(test_attrs::loc).get(), 99);
 
   // Verify structure.
   auto loaded_c1 = tree2->get_first_child(root);

--- a/hhds/tests/tree_wrapper_test.cpp
+++ b/hhds/tests/tree_wrapper_test.cpp
@@ -330,3 +330,30 @@ TEST(TreeWrappers, PrintScopeTypes) {
                     "  }\n"
                     "}\n");
 }
+
+TEST(TreeWrappers, PrintUsesBuiltinNameAttribute) {
+  auto tree = hhds::Tree::create();
+  tree->set_name("named");
+
+  const auto root  = tree->add_root_node();
+  const auto child = tree->add_child(root);
+
+  tree->set_type(root, 1);
+  tree->set_type(child, 2);
+  root.attr(hhds::attrs::name).set("program");
+  child.attr(hhds::attrs::name).set("literal");
+
+  const hhds::Type_entry type_table[] = {
+    {"invalid", hhds::Statement_class::Node},
+    {"module",  hhds::Statement_class::Node},
+    {"literal", hhds::Statement_class::Node},
+  };
+
+  hhds::Tree::PrintOptions options;
+  options.type_table = type_table;
+
+  EXPECT_EQ(tree->print(options), "named {\n"
+                                  "  %8  = program : module\n"
+                                  "  %16 = literal\n"
+                                  "}\n");
+}

--- a/hhds/tree.hpp
+++ b/hhds/tree.hpp
@@ -29,6 +29,8 @@
 #include <utility>
 #include <vector>
 
+#include "hhds/attr.hpp"
+#include "hhds/attrs/name.hpp"
 #include "hhds/graph_sizing.hpp"
 #include "hhds/tree_print.hpp"
 #include "iassert.hpp"
@@ -219,7 +221,7 @@ public:
 template <typename X>
 class PayloadForest;
 
-class Tree : public std::enable_shared_from_this<Tree> {
+class Tree : public std::enable_shared_from_this<Tree>, public Attr_host {
 private:
   std::vector<Tree_pointers>   pointers_stack;
   std::vector<std::bitset<64>> validity_stack;
@@ -399,6 +401,13 @@ public:
     [[nodiscard]] auto pre_order_class() const;
     [[nodiscard]] auto post_order_class() const;
     [[nodiscard]] auto sibling_order() const;
+
+    template <Attribute Tag>
+    [[nodiscard]] AttrRef<Tag> attr(Tag = {}) const {
+      I(tree_ptr != nullptr, "attr: node is not attached to a tree");
+      return AttrRef<Tag>(tree_ptr, make_node_attr_key(static_cast<uint64_t>(current_pos)));
+    }
+
     [[nodiscard]] bool operator==(const Node_class& other) const noexcept { return current_pos == other.current_pos; }
     [[nodiscard]] bool operator!=(const Node_class& other) const noexcept { return !(*this == other); }
 
@@ -1091,6 +1100,7 @@ private:
 
   [[nodiscard]] Type_entry resolve_print_type(Type type, const PrintOptions& options) const;
   [[nodiscard]] size_t     node_body_width(Tree_pos c, size_t name_width, const PrintOptions& options) const;
+  [[nodiscard]] std::optional<std::string> node_text_override(Tree_pos node_pos, const PrintOptions& options) const;
   void print_node(std::ostream& os, Tree_pos node_pos, size_t depth, const PrintAlign& align, const PrintOptions& options) const;
   void dump_node(std::ostream& os, Tree_pos node_pos, const std::string& prefix, bool is_last, const PrintOptions& options) const;
   void write_dump_node(std::ostream& os, Tree_pos node_pos, const std::string& prefix, bool is_last,
@@ -1099,9 +1109,10 @@ private:
   [[nodiscard]] PrintAlign compute_sibling_align(Tree_pos first_child, const PrintOptions& options) const;
   void                     recompute_body_width(PrintAlign& align, Tree_pos first_child, const PrintOptions& options) const;
   void                     recompute_body_width_recurse(PrintAlign& align, Tree_pos first_child, const PrintOptions& options) const;
+  void                     attr_note_modified() noexcept override { dirty_ = true; }
   mutable std::vector<Node_class> subs_cache_;
   mutable bool                    subs_cache_valid_ = false;
-  explicit Tree(Forest* forest = nullptr) : forest_ptr(forest) {}
+  explicit Tree(Forest* forest = nullptr) : forest_ptr(forest) { register_attr_tag<attrs::name_t>("hhds::attrs::name"); }
 };
 
 class TreeIO : public std::enable_shared_from_this<TreeIO> {
@@ -2881,6 +2892,7 @@ inline void Tree::delete_leaf(const Tree_pos& leaf_index) {
   const auto next_sibling_id   = get_sibling_next(leaf_index);
   const auto parent_index      = pointers_stack[leaf_chunk_id].get_parent();
 
+  erase_attr_object(make_node_attr_key(static_cast<uint64_t>(leaf_index)));
   _set_data_invalid(leaf_index);
   subs_cache_valid_ = false;
   if (leaf_index < static_cast<Tree_pos>(subnode_refs.size())) {
@@ -2976,6 +2988,7 @@ inline void Tree::clear() {
   pointers_stack.clear();
   validity_stack.clear();
   subnode_refs.clear();
+  discard_attr_stores();
   subs_cache_.clear();
   subs_cache_valid_ = false;
 }

--- a/hhds/tree_print.cpp
+++ b/hhds/tree_print.cpp
@@ -6,6 +6,18 @@
 
 namespace hhds {
 
+std::optional<std::string> Tree::node_text_override(Tree_pos node_pos, const PrintOptions& options) const {
+  const auto node = as_class(node_pos);
+  if (options.node_text) {
+    return options.node_text(node);
+  }
+  auto name_attr = node.attr(attrs::name);
+  if (name_attr.has()) {
+    return std::string(name_attr.get());
+  }
+  return std::nullopt;
+}
+
 Type_entry Tree::resolve_print_type(Type type, const PrintOptions& options) const {
   if (type >= 0 && static_cast<size_t>(type) < options.type_table.size()) {
     return options.type_table[static_cast<size_t>(type)];
@@ -29,8 +41,8 @@ size_t Tree::node_body_width(Tree_pos c, size_t name_width, const PrintOptions& 
     case Statement_class::Open_def:
     case Statement_class::Closed_def: {
       size_t w = 4 + te.name.size();
-      if (options.node_text) {
-        w += 1 + options.node_text(as_class(c)).size();
+      if (auto nt = node_text_override(c, options); nt.has_value()) {
+        w += 1 + nt->size();
       }
       return w;
     }
@@ -38,20 +50,19 @@ size_t Tree::node_body_width(Tree_pos c, size_t name_width, const PrintOptions& 
     case Statement_class::Open_call:
     case Statement_class::Closed_call: {
       size_t w = te.name.size();
-      if (options.node_text) {
-        w += 1 + options.node_text(as_class(c)).size();
+      if (auto nt = node_text_override(c, options); nt.has_value()) {
+        w += 1 + nt->size();
       }
       return w;
     }
 
     default: {  // Node
-      if (options.node_text) {
-        auto nt        = options.node_text(as_class(c));
-        bool has_colon = options.show_types && std::string_view(nt) != te.name;
+      if (auto nt = node_text_override(c, options); nt.has_value()) {
+        const bool has_colon = options.show_types && std::string_view(*nt) != te.name;
         if (has_colon) {
           return name_width + 3 + te.name.size();
         }
-        return nt.size();
+        return nt->size();
       }
       return te.name.size();
     }
@@ -71,11 +82,10 @@ void Tree::scan_align_group(PrintAlign& align, Tree_pos first_child, const Print
     const bool is_scope = te.sclass == Statement_class::Open_call || te.sclass == Statement_class::Closed_call
                           || te.sclass == Statement_class::Open_def || te.sclass == Statement_class::Closed_def;
 
-    if (options.node_text && te.sclass == Statement_class::Node) {
-      auto nt = options.node_text(as_class(c));
-      if (options.show_types && std::string_view(nt) != te.name) {
-        if (nt.size() > align.name_width) {
-          align.name_width = nt.size();
+    if (te.sclass == Statement_class::Node) {
+      if (auto nt = node_text_override(c, options); nt.has_value() && options.show_types && std::string_view(*nt) != te.name) {
+        if (nt->size() > align.name_width) {
+          align.name_width = nt->size();
         }
       }
     }
@@ -242,10 +252,9 @@ void Tree::print_node(std::ostream& os, Tree_pos node_pos, size_t depth, const P
       emit_pos(node_pos);
       os << " = def " << te.name;
       body_w = 4 + te.name.size();
-      if (options.node_text) {
-        auto nt = options.node_text(node);
-        os << ' ' << nt;
-        body_w += 1 + nt.size();
+      if (auto nt = node_text_override(node_pos, options); nt.has_value()) {
+        os << ' ' << *nt;
+        body_w += 1 + nt->size();
       }
       break;
     }
@@ -254,10 +263,9 @@ void Tree::print_node(std::ostream& os, Tree_pos node_pos, size_t depth, const P
       emit_pos(node_pos);
       os << " = " << te.name;
       body_w = te.name.size();
-      if (options.node_text) {
-        auto nt = options.node_text(node);
-        os << ' ' << nt;
-        body_w += 1 + nt.size();
+      if (auto nt = node_text_override(node_pos, options); nt.has_value()) {
+        os << ' ' << *nt;
+        body_w += 1 + nt->size();
       }
       break;
     }
@@ -265,18 +273,17 @@ void Tree::print_node(std::ostream& os, Tree_pos node_pos, size_t depth, const P
     default: {  // Node
       emit_pos(node_pos);
       os << " = ";
-      if (options.node_text) {
-        auto nt = options.node_text(node);
-        os << nt;
-        bool has_colon = options.show_types && std::string_view(nt) != te.name;
+      if (auto nt = node_text_override(node_pos, options); nt.has_value()) {
+        os << *nt;
+        const bool has_colon = options.show_types && std::string_view(*nt) != te.name;
         if (has_colon) {
-          if (align.name_width > nt.size()) {
-            os << std::string(align.name_width - nt.size(), ' ');
+          if (align.name_width > nt->size()) {
+            os << std::string(align.name_width - nt->size(), ' ');
           }
           os << " : " << te.name;
           body_w = align.name_width + 3 + te.name.size();
         } else {
-          body_w = nt.size();
+          body_w = nt->size();
         }
       } else {
         os << te.name;

--- a/hhds/tree_serial.cpp
+++ b/hhds/tree_serial.cpp
@@ -337,7 +337,7 @@ Tree::ReadDumpResult Tree::read_dump(const std::string& filename, std::span<cons
 // --------------------------------------------------------------------------
 
 static constexpr uint32_t TREE_BODY_MAGIC   = 0x48485442;  // "HHTB"
-static constexpr uint32_t TREE_BODY_VERSION = 1;
+static constexpr uint32_t TREE_BODY_VERSION = 2;
 static constexpr uint32_t ENDIAN_CHECK      = 0x01020304;
 
 void Tree::save_body(const std::string& dir_path) const {
@@ -366,6 +366,7 @@ void Tree::save_body(const std::string& dir_path) const {
             static_cast<std::streamsize>(validity_count * sizeof(std::bitset<64>)));
   ofs.write(reinterpret_cast<const char*>(subnode_refs.data()),
             static_cast<std::streamsize>(subnode_count * sizeof(Tree_pos)));
+  save_attr_stores(ofs);
   dirty_ = false;
 }
 
@@ -381,7 +382,7 @@ void Tree::load_body(const std::string& dir_path) {
   ifs.read(reinterpret_cast<char*>(&version), sizeof(version));
   ifs.read(reinterpret_cast<char*>(&endian), sizeof(endian));
   assert(magic == TREE_BODY_MAGIC && "load_body: bad magic");
-  assert(version == TREE_BODY_VERSION && "load_body: unsupported version");
+  assert((version == 1 || version == TREE_BODY_VERSION) && "load_body: unsupported version");
   assert(endian == ENDIAN_CHECK && "load_body: endian mismatch");
 
   uint64_t pointers_count = 0, validity_count = 0, subnode_count = 0;
@@ -400,6 +401,14 @@ void Tree::load_body(const std::string& dir_path) {
   subnode_refs.resize(subnode_count);
   ifs.read(reinterpret_cast<char*>(subnode_refs.data()),
            static_cast<std::streamsize>(subnode_count * sizeof(Tree_pos)));
+
+  if (version >= 2) {
+    load_attr_stores(ifs);
+  } else {
+    discard_attr_stores();
+  }
+  subs_cache_valid_ = false;
+  subs_cache_.clear();
   dirty_ = false;
 }
 


### PR DESCRIPTION
## Summary

This PR adds the first full HHDS attribute system implementation across graph and tree bodies.

HHDS can now store typed per-object metadata on `Graph` and `Tree`, access it through wrapper APIs like `node.attr(tag)` / `pin.attr(tag)`, persist it with body save/load, and clean it up correctly on delete/clear. It also adds the built-in `hhds::attrs::name` attribute and uses it automatically in default tree printing.

## What’s Included

- Add shared attribute infrastructure in `hhds/attr.hpp`
  - `flat_storage` / `hier_storage`
  - `Attribute` concept
  - generic `AttrRef<Tag>`
  - per-host typed attr stores with persistence support
  - downstream attr registration for deserialization
- Add built-in `hhds::attrs::name` in `hhds/attrs/name.hpp`
- Wire attrs into graph wrappers
  - `Node::attr(tag)`
  - `Pin::attr(tag)`
  - flat attrs and hier attrs both supported on graph traversal wrappers
- Wire attrs into tree wrappers
  - `Tree::Node_class::attr(tag)`
  - attr cleanup on subtree delete / clear
- Persist attr stores in graph and tree body save/load
  - version bump for body format
  - backward-compatible load for previous body version
- Add default name-based tree printing
  - if no custom `node_text` callback is provided, `print()` uses `hhds::attrs::name` when available
- Add a basic `Graph::print()` surface using built-in names

## Tests

Added/updated tests for:

- flat get/set/has/del on graph nodes and pins
- node vs port-0 pin attr-key separation
- attr cleanup on node deletion
- `attr_clear()` vs `clear()` semantics
- graph hier attrs with traversal context
- graph/tree attr persistence round-trip
- downstream attr registration for persistence
- default tree printing via built-in `name`

Verified with:

```bash
bazel test //hhds:graph_test //hhds:test_storage //hhds:tree_wrapper_test //hhds:iterators_impl
```

## Notes

- `pin_name` remains a dynamic property via `pin.get_pin_name()`, not a stored attr.
- This PR focuses on the core attr system, persistence, and wrapper API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a generic attribute system for attaching custom metadata to nodes and pins.
  * Added built-in name attribute to label nodes and pins.
  * Enhanced printing to display attribute values in output.
  * Added attribute persistence: attributes are now saved and loaded with graph/tree serialization.

* **Tests**
  * Added comprehensive test coverage for attribute operations and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->