### PR TITLE
hhds/graph: add hierarchy-only iterator (Graph::hier_range)

### DIFF
--- a/hhds/graph.cpp
+++ b/hhds/graph.cpp
@@ -707,6 +707,7 @@ void Graph::invalidate_from_library() noexcept {
     tree_->clear();
   }
   subnode_tree_pos_.clear();
+  tree_pos_to_nid_.clear();
   input_pins_.clear();
   output_pins_.clear();
 }
@@ -731,6 +732,7 @@ void Graph::clear_graph() {
   }
   (void)tree_->add_root();
   subnode_tree_pos_.clear();
+  tree_pos_to_nid_.clear();
   invalidate_traversal_caches();
 }
 
@@ -778,6 +780,7 @@ void Graph::clear() {
   }
   (void)tree_->add_root();
   subnode_tree_pos_.clear();
+  tree_pos_to_nid_.clear();
   invalidate_traversal_caches();
   if (auto graphio = get_io()) {
     for (const auto& input : graphio->input_pin_decls_) {
@@ -1559,6 +1562,7 @@ void Graph::set_subnode(Nid nid, Gid gid) {
   if (tree_ && subnode_tree_pos_.find(nid) == subnode_tree_pos_.end()) {
     const Tree_pos child_pos = tree_->add_child(static_cast<Tree_pos>(ROOT));
     subnode_tree_pos_.emplace(nid, child_pos);
+    tree_pos_to_nid_.emplace(child_pos, nid);
   }
 
   // Stamp node type so the forward iterator can O(1) tell whether this
@@ -2077,6 +2081,170 @@ ForwardHierIterator& ForwardHierIterator::operator++() {
 }
 
 ForwardHierIterator ForwardHierRange::begin() const { return ForwardHierIterator(graph_); }
+
+// --- Hier_instance members ---
+
+Gid Hier_instance::get_target_gid() const {
+  if (parent_graph_ == nullptr || !parent_graph_->is_node_valid(parent_nid_)) {
+    return Gid_invalid;
+  }
+  const auto* entry = parent_graph_->ref_node(parent_nid_);
+  if (!entry->has_subnode()) {
+    return Gid_invalid;
+  }
+  return entry->get_subnode();
+}
+
+std::shared_ptr<Graph> Hier_instance::get_target_graph() const {
+  const Gid target = get_target_gid();
+  if (target == Gid_invalid || parent_graph_ == nullptr || parent_graph_->owner_lib_ == nullptr) {
+    return {};
+  }
+  if (!parent_graph_->owner_lib_->has_graph(target)) {
+    return {};
+  }
+  // owner_lib_ is a const GraphLibrary* on Graph (libraries are immutable from
+  // the graph's perspective) — cast to get the non-const get_graph overload
+  // since Hier_instance is designed to hand out a mutable handle for
+  // navigation/mutation, consistent with how Graph::get_io returns a
+  // mutable GraphIO.
+  auto* lib = const_cast<GraphLibrary*>(parent_graph_->owner_lib_);
+  return lib->get_graph(target);
+}
+
+Node_class Hier_instance::get_parent_node() const {
+  if (!is_valid()) {
+    return Node_class();
+  }
+  // Build a hier-context Node_class matching the key that fast_hier/forward_hier
+  // would assign to this same subnode node during their traversal — hier_pos
+  // is the parent frame's hier_pos, not this instance's own tree_pos.
+  return Node_class(parent_graph_, root_gid_, hier_pos_, parent_nid_);
+}
+
+bool Hier_instance::is_valid() const noexcept {
+  if (parent_graph_ == nullptr) {
+    return false;
+  }
+  if (!parent_graph_->is_node_valid(parent_nid_)) {
+    return false;
+  }
+  const auto* entry = parent_graph_->ref_node(parent_nid_);
+  return entry->has_subnode();
+}
+
+// --- HierIterator / HierRange ---
+//
+// The walker keeps one Frame per currently-open tree level. advance_to_next
+// _instance moves the top frame's pre-order cursor forward until it lands on
+// a Tree_pos whose reverse-lookup hit is still a live subnode (stale tombstone
+// tree positions left behind by delete_node are silently skipped). When a
+// frame's iterator reaches end, the frame pops and its Gid is released from
+// active_graphs_. operator++ is responsible for pushing the target-graph
+// frame when the yielded instance expands into an as-yet-unvisited subgraph.
+
+HierIterator::HierIterator(Graph* root_graph) {
+  if (root_graph == nullptr || root_graph->tree_ == nullptr) {
+    return;
+  }
+  root_gid_ = root_graph->self_gid_;
+  // Seed the top frame with pre_order over the root graph's tree, plus a
+  // hier_pos of ROOT so the yielded instances match the top-level naming that
+  // fast_hier and forward_hier produce (their root frame also uses ROOT).
+  auto* tree = root_graph->tree_.get();
+  stack_.push_back(Frame{root_graph,
+                         Tree::pre_order_iterator(static_cast<Tree_pos>(ROOT), tree, false),
+                         Tree::pre_order_iterator(INVALID, tree, false),
+                         static_cast<Tree_pos>(ROOT)});
+  if (root_gid_ != Gid_invalid) {
+    active_graphs_.insert(root_gid_);
+  }
+  advance_to_next_instance();
+}
+
+void HierIterator::advance_to_next_instance() {
+  while (!stack_.empty()) {
+    Frame& frame = stack_.back();
+    while (frame.cur != frame.end) {
+      const Tree_pos pos = (*frame.cur).get_debug_nid();
+      if (pos == static_cast<Tree_pos>(ROOT)) {
+        // ROOT is a structural placeholder — it never corresponds to a
+        // subnode. Skip it silently.
+        ++frame.cur;
+        continue;
+      }
+      auto it = frame.graph->tree_pos_to_nid_.find(pos);
+      if (it == frame.graph->tree_pos_to_nid_.end()) {
+        // Orphan tree node (shouldn't happen in normal operation — every
+        // tree node is inserted by set_subnode, which also updates the map).
+        // Skip defensively so a future tree-only API can't hang iteration.
+        ++frame.cur;
+        continue;
+      }
+      const Nid owner_nid = it->second;
+      if (!frame.graph->is_node_valid(owner_nid)) {
+        // Stale entry left after delete_node — the node is tombstoned but
+        // the tree position / map entry weren't cleaned up (current
+        // delete_node doesn't touch the structure tree). Skip.
+        ++frame.cur;
+        continue;
+      }
+      const auto* entry = frame.graph->ref_node(owner_nid);
+      if (!entry->has_subnode()) {
+        ++frame.cur;
+        continue;
+      }
+      return;
+    }
+    const Gid popped = frame.graph->self_gid_;
+    stack_.pop_back();
+    if (popped != Gid_invalid) {
+      active_graphs_.erase(popped);
+    }
+  }
+}
+
+Hier_instance HierIterator::operator*() const {
+  const Frame&   frame     = stack_.back();
+  const Tree_pos pos       = (*frame.cur).get_debug_nid();
+  auto           nid_it    = frame.graph->tree_pos_to_nid_.find(pos);
+  const Nid      owner_nid = nid_it->second;
+  return Hier_instance(frame.graph, root_gid_, frame.hier_pos, pos, owner_nid);
+}
+
+HierIterator& HierIterator::operator++() {
+  Frame&         frame    = stack_.back();
+  const Tree_pos this_pos  = (*frame.cur).get_debug_nid();
+  auto           it        = frame.graph->tree_pos_to_nid_.find(this_pos);
+  const Nid      owner_nid = (it != frame.graph->tree_pos_to_nid_.end()) ? it->second : static_cast<Nid>(0);
+  const auto*    entry     = frame.graph->ref_node(owner_nid);
+  const Gid      sub       = entry->get_subnode();
+  const auto*    lib       = frame.graph->owner_lib_;
+  ++frame.cur;
+  if (sub != Gid_invalid && lib != nullptr && lib->has_graph(sub) && active_graphs_.find(sub) == active_graphs_.end()) {
+    Graph* child = const_cast<Graph*>(lib->get_graph(sub).get());
+    if (child->tree_ != nullptr) {
+      auto* child_tree = child->tree_.get();
+      active_graphs_.insert(sub);
+      // this_pos is the parent subnode's tree_pos within frame.graph — it
+      // becomes the hier_pos for every instance yielded from the child
+      // frame, matching fast_hier's semantics.
+      stack_.push_back(Frame{child,
+                             Tree::pre_order_iterator(static_cast<Tree_pos>(ROOT), child_tree, false),
+                             Tree::pre_order_iterator(INVALID, child_tree, false),
+                             this_pos});
+    }
+  }
+  advance_to_next_instance();
+  return *this;
+}
+
+HierIterator HierRange::begin() const { return HierIterator(graph_); }
+
+HierRange Graph::hier_range() const noexcept {
+  assert_accessible();
+  return HierRange(const_cast<Graph*>(this));
+}
 
 void Graph::del_edge_int(Vid driver_id, Vid sink_id) {
   auto pool = get_overflow_pool();
@@ -2692,6 +2860,7 @@ void Graph::load_body(const std::string& dir_path) {
   }
   (void)tree_->add_root();
   subnode_tree_pos_.clear();
+  tree_pos_to_nid_.clear();
   for (size_t i = 1; i < node_table.size(); ++i) {
     if (!node_table[i].is_alive() || !node_table[i].has_subnode()) {
       continue;
@@ -2699,6 +2868,7 @@ void Graph::load_body(const std::string& dir_path) {
     const Nid      subnode_nid = static_cast<Nid>(i) << 2;
     const Tree_pos child_pos   = tree_->add_child(static_cast<Tree_pos>(ROOT));
     subnode_tree_pos_.emplace(subnode_nid, child_pos);
+    tree_pos_to_nid_.emplace(child_pos, subnode_nid);
   }
 
   invalidate_traversal_caches();

--- a/hhds/graph.hpp
+++ b/hhds/graph.hpp
@@ -71,6 +71,9 @@ class ForwardFlatIterator;
 class ForwardFlatRange;
 class ForwardHierIterator;
 class ForwardHierRange;
+class Hier_instance;
+class HierIterator;
+class HierRange;
 
 enum class Handle_context : uint8_t { Class, Flat, Hier };
 
@@ -247,6 +250,55 @@ public:
 
 private:
   friend class Graph;
+};
+
+// Handle for one subnode instance in the structure-tree walk driven by
+// Graph::hier_range(). Unlike Node_class (which yields every graph node),
+// Hier_instance yields exactly once per subnode — so hierarchy traversals
+// pay O(hier_size), not O(graph_size). Carries enough state to both
+// identify the instance (parent_graph + tree_pos) and resolve what it
+// expands into (target_gid). hier_pos matches fast_hier/forward_hier's
+// per-instance token so per-instance attribute lookups agree across APIs.
+class Hier_instance {
+public:
+  Hier_instance() = default;
+  Hier_instance(Graph* parent_graph, Gid root_gid, Tree_pos hier_pos, Tree_pos tree_pos, Nid parent_nid)
+      : parent_graph_(parent_graph)
+      , root_gid_(root_gid)
+      , hier_pos_(hier_pos)
+      , tree_pos_(tree_pos)
+      , parent_nid_(parent_nid) {}
+
+  [[nodiscard]] Graph*                 get_parent_graph() const noexcept { return parent_graph_; }
+  [[nodiscard]] Gid                    get_root_gid() const noexcept { return root_gid_; }
+  [[nodiscard]] Tree_pos               get_tree_pos() const noexcept { return tree_pos_; }
+  [[nodiscard]] Tree_pos               get_hier_pos() const noexcept { return hier_pos_; }
+  [[nodiscard]] Nid                    get_parent_nid() const noexcept { return parent_nid_; }
+  [[nodiscard]] Gid                    get_target_gid() const;
+  [[nodiscard]] std::shared_ptr<Graph> get_target_graph() const;
+  [[nodiscard]] Node_class             get_parent_node() const;
+  [[nodiscard]] bool                   is_valid() const noexcept;
+  [[nodiscard]] bool                   is_invalid() const noexcept { return !is_valid(); }
+
+  [[nodiscard]] bool operator==(const Hier_instance& other) const noexcept {
+    return parent_graph_ == other.parent_graph_ && tree_pos_ == other.tree_pos_ && hier_pos_ == other.hier_pos_;
+  }
+  [[nodiscard]] bool operator!=(const Hier_instance& other) const noexcept { return !(*this == other); }
+
+  template <typename H>
+  friend H AbslHashValue(H h, const Hier_instance& inst) {
+    return H::combine(std::move(h), reinterpret_cast<uintptr_t>(inst.parent_graph_), inst.tree_pos_, inst.hier_pos_);
+  }
+
+private:
+  Graph*   parent_graph_ = nullptr;
+  Gid      root_gid_     = Gid_invalid;
+  Tree_pos hier_pos_     = INVALID;
+  Tree_pos tree_pos_     = INVALID;
+  Nid      parent_nid_   = 0;
+
+  friend class Graph;
+  friend class HierIterator;
 };
 
 using Node = Node_class;
@@ -456,6 +508,13 @@ public:
   [[nodiscard]] ForwardFlatRange  forward_flat() const noexcept;
   [[nodiscard]] FastHierRange     fast_hier() const noexcept;
   [[nodiscard]] ForwardHierRange  forward_hier() const noexcept;
+  // Hierarchy-only traversal: yields one Hier_instance per subnode in the
+  // structure tree, recursing into each instance's target graph (cycle-
+  // guarded by active_graphs). Walks tree_ alone — it never iterates
+  // node_table, so cost is proportional to the hierarchy size (≪ number
+  // of graph nodes). Use this for instance counts, module-tree walks, and
+  // path resolution rather than fast_hier (which visits every graph node).
+  [[nodiscard]] HierRange         hier_range() const noexcept;
   void               display_graph() const;
   void               display_next_pin_of_node() const;
 
@@ -527,6 +586,12 @@ private:
   // Nid back to its Tree_pos so del_node / debug cycle checks can find it.
   std::shared_ptr<Tree>                          tree_;
   ankerl::unordered_dense::map<Nid, Tree_pos>    subnode_tree_pos_;
+  // Reverse map so hier_range can resolve a Tree_pos back to its owning Nid
+  // in O(1) during tree-pre-order iteration. Kept in lockstep with
+  // subnode_tree_pos_ — every set_subnode / load_body insertion updates
+  // both, and all three clear sites (release_storage, clear_graph, clear)
+  // clear both.
+  ankerl::unordered_dense::map<Tree_pos, Nid>    tree_pos_to_nid_;
   // Forward-traversal caches, shared across forward_class / forward_flat /
   // forward_hier for this graph body. Only the Pass-2 deferral list and the
   // initial in-edge counts are kept — the Pass-1 emission order is replayed
@@ -562,6 +627,9 @@ private:
   friend class ForwardFlatRange;
   friend class ForwardHierIterator;
   friend class ForwardHierRange;
+  friend class HierIterator;
+  friend class HierRange;
+  friend class Hier_instance;
 };
 
 // Lazy, single-pass iterator over a graph's live nodes (node_table scan,
@@ -878,6 +946,64 @@ public:
   explicit ForwardHierRange(Graph* graph) noexcept : graph_(graph) {}
   [[nodiscard]] ForwardHierIterator begin() const;
   [[nodiscard]] ForwardHierIterator end() const noexcept { return ForwardHierIterator{}; }
+
+private:
+  Graph* graph_;
+};
+
+// Structure-tree pre-order iterator. Walks tree_ (skipping ROOT) and, when
+// a tree position corresponds to a live subnode, descends into the subnode's
+// target graph's tree to continue recursively. active_graphs_ guards
+// against structural cycles (which are disallowed but not enforced in
+// release builds). Move-only: holds per-walk working state (frame stack +
+// active_graphs set) that we don't want copied implicitly.
+class HierIterator {
+public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type        = Hier_instance;
+  using difference_type   = std::ptrdiff_t;
+  using pointer           = void;
+  using reference         = Hier_instance;
+
+  HierIterator() noexcept                      = default;
+  HierIterator(const HierIterator&)            = delete;
+  HierIterator(HierIterator&&) noexcept        = default;
+  HierIterator& operator=(const HierIterator&) = delete;
+  HierIterator& operator=(HierIterator&&) noexcept = default;
+  ~HierIterator()                              = default;
+
+  [[nodiscard]] Hier_instance operator*() const;
+  HierIterator&               operator++();
+  [[nodiscard]] bool operator==(const HierIterator& o) const noexcept { return stack_.empty() && o.stack_.empty(); }
+  [[nodiscard]] bool operator!=(const HierIterator& o) const noexcept { return !(*this == o); }
+
+private:
+  struct Frame {
+    Graph*                   graph;     // the graph whose tree is being walked
+    Tree::pre_order_iterator cur;       // cursor into graph->tree_->pre_order()
+    Tree::pre_order_iterator end;       // matching end sentinel
+    Tree_pos                 hier_pos;  // parent subnode's tree_pos within its graph, or ROOT for the top frame
+  };
+
+  explicit HierIterator(Graph* root_graph);
+  // Advance cur_ until it lands on a Tree_pos that corresponds to a live
+  // subnode in the current frame's graph. Pops exhausted frames (unwinding
+  // active_graphs_ as we go) and keeps walking until either a yieldable
+  // instance is found or the stack is empty.
+  void advance_to_next_instance();
+
+  Gid                               root_gid_ = Gid_invalid;
+  std::vector<Frame>                stack_;
+  ankerl::unordered_dense::set<Gid> active_graphs_;
+
+  friend class HierRange;
+};
+
+class HierRange {
+public:
+  explicit HierRange(Graph* graph) noexcept : graph_(graph) {}
+  [[nodiscard]] HierIterator begin() const;
+  [[nodiscard]] HierIterator end() const noexcept { return HierIterator{}; }
 
 private:
   Graph* graph_;

--- a/hhds/tests/graph_test.cpp
+++ b/hhds/tests/graph_test.cpp
@@ -218,6 +218,137 @@ void test_subnode_with_loop_last_pin_marks_node() {
   assert((buf_inst.get_type() & 1) == 0);
 }
 
+void test_hier_range_flat_graph_is_empty() {
+  // A graph with no subnodes should produce an empty hier_range — even when
+  // it has plain (non-subnode) graph nodes and IO pins.
+  hhds::GraphLibrary lib;
+  auto               gio   = lib.create_io("flat");
+  gio->add_input("in", 0);
+  gio->add_output("out", 0);
+  auto               graph = gio->create_graph();
+  (void)graph->create_node();
+  (void)graph->create_node();
+
+  size_t count = 0;
+  for (auto inst : graph->hier_range()) {
+    (void)inst;
+    ++count;
+  }
+  assert(count == 0);
+}
+
+void test_hier_range_yields_one_per_subnode() {
+  // Two leaf submodules, three top-level instances (two of leaf_a, one of
+  // leaf_b). hier_range should yield exactly 3 entries — one per instance,
+  // even when multiple instances share a GraphIO.
+  hhds::GraphLibrary lib;
+
+  auto leaf_a = lib.create_io("leaf_a");
+  (void)leaf_a->create_graph();
+  auto leaf_b = lib.create_io("leaf_b");
+  (void)leaf_b->create_graph();
+
+  auto top_gio = lib.create_io("top");
+  auto top     = top_gio->create_graph();
+
+  auto i1 = top->create_node();
+  i1.set_subnode(leaf_a);
+  auto i2 = top->create_node();
+  i2.set_subnode(leaf_a);
+  auto i3 = top->create_node();
+  i3.set_subnode(leaf_b);
+
+  std::vector<hhds::Gid> targets;
+  std::vector<hhds::Nid> parents;
+  for (auto inst : top->hier_range()) {
+    targets.push_back(inst.get_target_gid());
+    parents.push_back(inst.get_parent_nid());
+    assert(inst.get_parent_graph() == top.get());
+    assert(inst.is_valid());
+  }
+  assert(targets.size() == 3);
+  // Tree inserts siblings in set_subnode call order, so we expect a, a, b.
+  assert(targets[0] == leaf_a->get_gid());
+  assert(targets[1] == leaf_a->get_gid());
+  assert(targets[2] == leaf_b->get_gid());
+  assert(parents[0] == i1.get_debug_nid());
+  assert(parents[1] == i2.get_debug_nid());
+  assert(parents[2] == i3.get_debug_nid());
+}
+
+void test_hier_range_descends_into_nested_subnodes() {
+  // top contains mid; mid contains leaf. hier_range from top should yield
+  // both the mid instance AND the leaf instance (seen through mid's body),
+  // in that order (mid first, then leaf via recursion).
+  hhds::GraphLibrary lib;
+
+  auto leaf_gio = lib.create_io("leaf");
+  (void)leaf_gio->create_graph();
+
+  auto mid_gio = lib.create_io("mid");
+  auto mid     = mid_gio->create_graph();
+  auto mid_inst_of_leaf = mid->create_node();
+  mid_inst_of_leaf.set_subnode(leaf_gio);
+
+  auto top_gio = lib.create_io("top");
+  auto top     = top_gio->create_graph();
+  auto top_inst_of_mid = top->create_node();
+  top_inst_of_mid.set_subnode(mid_gio);
+
+  std::vector<hhds::Gid> targets;
+  for (auto inst : top->hier_range()) {
+    targets.push_back(inst.get_target_gid());
+  }
+  assert(targets.size() == 2);
+  assert(targets[0] == mid_gio->get_gid());
+  assert(targets[1] == leaf_gio->get_gid());
+}
+
+void test_hier_range_cycle_guard() {
+  // Self-referencing submodule must not cause infinite recursion —
+  // active_graphs_ deduplicates on descent. Cycles are disallowed by design
+  // (see todo.md Task 2), but the iterator must be robust in release
+  // builds regardless.
+  hhds::GraphLibrary lib;
+
+  auto self_gio = lib.create_io("self");
+  auto self     = self_gio->create_graph();
+  auto inst     = self->create_node();
+  inst.set_subnode(self_gio);
+
+  size_t count = 0;
+  for (auto it : self->hier_range()) {
+    assert(it.get_target_gid() == self_gio->get_gid());
+    ++count;
+    assert(count < 100 && "cycle guard failed — hier_range is not terminating");
+  }
+  assert(count == 1);
+}
+
+void test_hier_range_target_graph_and_parent_node() {
+  // get_target_graph() should resolve to the actual body, and
+  // get_parent_node() should return a valid hier-context Node_class usable
+  // for attribute queries.
+  hhds::GraphLibrary lib;
+  auto               leaf_gio = lib.create_io("leaf");
+  auto               leaf     = leaf_gio->create_graph();
+
+  auto top_gio = lib.create_io("top");
+  auto top     = top_gio->create_graph();
+  auto inst    = top->create_node();
+  inst.set_subnode(leaf_gio);
+
+  auto hier = top->hier_range();
+  auto it   = hier.begin();
+  assert(it != hier.end());
+  auto handle = *it;
+  assert(handle.get_target_graph() == leaf);
+  auto pnode = handle.get_parent_node();
+  assert(pnode.is_valid());
+  assert(pnode.is_hier());
+  assert(pnode.get_debug_nid() == inst.get_debug_nid());
+}
+
 }  // namespace
 
 int main() {
@@ -228,6 +359,11 @@ int main() {
   test_forward_loop_last_is_source();
   test_forward_out_of_order_uses_pending_list();
   test_subnode_with_loop_last_pin_marks_node();
+  test_hier_range_flat_graph_is_empty();
+  test_hier_range_yields_one_per_subnode();
+  test_hier_range_descends_into_nested_subnodes();
+  test_hier_range_cycle_guard();
+  test_hier_range_target_graph_and_parent_node();
   std::cout << "graph_test passed\n";
   return 0;
 }

--- a/todo.md
+++ b/todo.md
@@ -4,35 +4,7 @@ Design decisions from recent sessions are captured in `hhds/CLAUDE.md` and
 `~/.claude/projects/-Users-renau-projs-hhds/memory/`. Treat this file as the
 implementation queue.
 
-## 1. "Hierarchy-only" iterator
-
-**What:** An iterator that walks the structure tree alone — no graph
-node_table iteration. Yields one `Node` per subnode instance (or one
-handle per tree node, shape TBD).
-
-**Why:** User noted graph nodes outnumber hierarchy nodes ~1000×. For
-hierarchy inspection (module trees, instance counts, path resolution)
-iterating graph nodes wastes time.
-
-**Shape sketch:**
-```cpp
-class HierIterator { ... };
-class HierRange    { ... };
-
-Graph::hier_range() -> HierRange;   // walks tree_, yields instance handles
-```
-
-Instance handle probably looks like `(Graph* parent_graph, Tree_pos pos,
-Gid target_gid)` — enough to query subnode target + identify the
-instance — plus the tree position to drive navigation APIs.
-
-**Interplay with existing `fast_hier`:** orthogonal. `fast_hier` = "walk
-every graph node in the hierarchy," `hier_range` = "walk the hierarchy
-instance tree only."
-
----
-
-## 2. Debug-only cycle check in `set_subnode`
+## 1. Debug-only cycle check in `set_subnode`
 
 **What:** In debug builds, when `set_subnode(node, gid)` is called,
 verify no cycle would be created in the structure tree forest.
@@ -47,7 +19,7 @@ in subnode count, which is bounded by hierarchy size (≪ graph size).
 
 ---
 
-## 3. Optional: eliminate `context_` field entirely
+## 2. Optional: eliminate `context_` field entirely
 
 **What:** Drop `Context context_` and discriminate by field nullity:
 - `root_gid_ == Gid_invalid` → Class
@@ -66,7 +38,7 @@ assignment.
 
 ---
 
-## 4. Optional: `root_graph_` as `Graph*` instead of `Gid`
+## 3. Optional: `root_graph_` as `Graph*` instead of `Gid`
 
 **What:** Store the root as a pointer rather than an id. Parallels how
 `graph_` works.


### PR DESCRIPTION
## Summary

- Adds `Graph::hier_range()` — a tree-only traversal that yields one `Hier_instance` per subnode, without scanning `node_table`. Cost is O(hier_size), whereas `fast_hier` pays O(graph_size).
- New public types: `Hier_instance` (parent_graph / parent_nid / target_gid / tree_pos / hier_pos accessors, plus `get_target_graph()` and `get_parent_node()`), `HierIterator`, `HierRange`.
- Adds reverse map `tree_pos_to_nid_` alongside `subnode_tree_pos_` for O(1) `Tree_pos → Nid` lookup during pre-order; kept in lockstep at all 5 write/clear sites (`set_subnode`, `load_body`, `clear`, `clear_graph`, `release_storage`).
- Iterator is cycle-safe (`active_graphs_` blocks re-descent into an already-open graph) and stale-safe (silently skips tree entries whose owning node was tombstoned by `delete_node`).
- `hier_pos` matches `fast_hier` / `forward_hier` semantics, so per-instance attribute lookups agree across traversal APIs.

Implements task 1 from `todo.md`.

## Test plan

- [x] `bazel test //hhds:all` — all 14 targets pass, including the 5 contract tests (untouched).
- [x] New cases in `hhds/tests/graph_test.cpp`:
  - [x] flat graph (no subnodes) yields empty range
  - [x] three top-level instances (two sharing a GraphIO) yield 3 handles in `set_subnode` order
  - [x] nested hierarchy (top → mid → leaf) recurses and yields both instances
  - [x] self-referencing subnode terminates after 1 yield (cycle guard)
  - [x] `get_target_graph()` resolves to the correct body; `get_parent_node()` returns a valid hier-context `Node_class`
- [ ] Downstream caller adoption (not in this PR) — follow-up to migrate any code currently using `fast_hier` for hierarchy-only inspection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hierarchical traversal API: `Graph::hier_range()` enables efficient traversal of graph hierarchies with automatic descent into nested subgraphs.
  * Introduced `Hier_instance` handle type with validation and resolution methods for accessing hierarchical context information.
  * Built-in cycle detection safeguards traversal of complex nested structures.

* **Tests**
  * Added comprehensive test coverage for hierarchical traversal semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->