### PR TITLE
Add Zhang-Shasha tree edit distance algorithm

### DIFF
--- a/hhds/BUILD.bazel
+++ b/hhds/BUILD.bazel
@@ -386,6 +386,21 @@ cc_binary(
     ],
 )
 
+cc_library(
+    name = "tree_edit_distance",
+    hdrs = ["tree_edit_distance.hpp"],
+    deps = [":core"],
+)
+
+cc_test(
+    name = "tree_edit_distance_test",
+    srcs = ["tests/tree_edit_distance_test.cpp"],
+    deps = [
+        ":core",
+        ":tree_edit_distance",
+    ],
+)
+
 # cc_binary(
 #     name = "graph_bin",
 #     srcs = ["graph_main.cpp"],

--- a/hhds/tests/tree_edit_distance_test.cpp
+++ b/hhds/tests/tree_edit_distance_test.cpp
@@ -1,0 +1,129 @@
+#include "hhds/tree_edit_distance.hpp"
+
+#include <cassert>
+#include <iostream>
+
+#include "hhds/tree.hpp"
+
+void test_identical_trees() {
+  ::std::cout << "Test 1: Identical trees → distance = 0\n";
+  auto t1 = hhds::Tree::create();
+  auto t2 = hhds::Tree::create();
+
+  auto r1 = t1->add_root_node();
+  r1.set_type(1);
+  auto c1 = r1.add_child();
+  c1.set_type(2);
+  auto g1 = c1.add_child();
+  g1.set_type(3);
+
+  auto r2 = t2->add_root_node();
+  r2.set_type(1);
+  auto c2 = r2.add_child();
+  c2.set_type(2);
+  auto g2 = c2.add_child();
+  g2.set_type(3);
+
+  auto res = hhds::TreeEditDistance::compute(t1, t2);
+  ::std::cout << "  Distance: " << res.distance << " (expected 0.0)\n";
+  assert(res.distance == 0.0 && "Identical trees should have distance 0");
+}
+
+void test_single_relabel() {
+  ::std::cout << "Test 2: Single relabel → distance = 1\n";
+  auto t1 = hhds::Tree::create();
+  auto t2 = hhds::Tree::create();
+
+  // Tree 1
+  auto r1 = t1->add_root_node();
+  r1.set_type(1);
+  auto c1 = r1.add_child();
+  c1.set_type(2);
+
+  // Tree 2: same structure, different middle node type
+  auto r2 = t2->add_root_node();
+  r2.set_type(1);
+  auto c2 = r2.add_child();
+  c2.set_type(99);
+
+  auto res = hhds::TreeEditDistance::compute(t1, t2);
+  ::std::cout << "  Distance: " << res.distance << " (expected 1.0)\n";
+  assert(res.distance == 1.0 && "Single relabel should cost 1.0");
+}
+
+void test_single_deletion() {
+  ::std::cout << "Test 3: Single deletion → distance = 1\n";
+  auto t1 = hhds::Tree::create();
+  auto t2 = hhds::Tree::create();
+
+  // Tree 1: A → [B, C]
+  auto r1 = t1->add_root_node();
+  r1.set_type(1);
+  auto b = r1.add_child();
+  b.set_type(2);
+  auto c = b.append_sibling();
+  c.set_type(3);
+
+  // Tree 2: A → [B]  (C deleted)
+  auto r2 = t2->add_root_node();
+  r2.set_type(1);
+  auto b2 = r2.add_child();
+  b2.set_type(2);
+
+  auto res = hhds::TreeEditDistance::compute(t1, t2);
+  ::std::cout << "  Distance: " << res.distance << " (expected 1.0)\n";
+  assert(res.distance == 1.0 && "Single deletion should cost 1.0");
+}
+
+void test_single_insertion() {
+  ::std::cout << "Test 4: Single insertion → distance = 1\n";
+  auto t1 = hhds::Tree::create();
+  auto t2 = hhds::Tree::create();
+
+  // Tree 1: A → [B]
+  auto r1 = t1->add_root_node();
+  r1.set_type(1);
+  auto b = r1.add_child();
+  b.set_type(2);
+
+  // Tree 2: A → [B, C]  (C inserted)
+  auto r2 = t2->add_root_node();
+  r2.set_type(1);
+  auto b2 = r2.add_child();
+  b2.set_type(2);
+  auto c2 = b2.append_sibling();
+  c2.set_type(3);
+
+  auto res = hhds::TreeEditDistance::compute(t1, t2);
+  ::std::cout << "  Distance: " << res.distance << " (expected 1.0)\n";
+  assert(res.distance == 1.0 && "Single insertion should cost 1.0");
+}
+
+int main() {
+  ::std::cout << "\n════════════════════════════════════════\n";
+  ::std::cout << "Zhang-Shasha Algorithm Test Suite\n";
+  ::std::cout << "════════════════════════════════════════\n\n";
+
+  try {
+    test_identical_trees();
+    ::std::cout << "  ✓ PASS\n\n";
+
+    test_single_relabel();
+    ::std::cout << "  ✓ PASS\n\n";
+
+    test_single_deletion();
+    ::std::cout << "  ✓ PASS\n\n";
+
+    test_single_insertion();
+    ::std::cout << "  ✓ PASS\n\n";
+
+    ::std::cout << "════════════════════════════════════════\n";
+    ::std::cout << "All tests PASSED ✓\n";
+    ::std::cout << "════════════════════════════════════════\n";
+  } catch (const ::std::exception& e) {
+    ::std::cout << "✗ FAILED: " << e.what() << "\n";
+    return 1;
+  }
+
+  return 0;
+}

--- a/hhds/tree_edit_distance.hpp
+++ b/hhds/tree_edit_distance.hpp
@@ -1,0 +1,185 @@
+#pragma once
+
+// tree_edit_distance.hpp
+// Zhang-Shasha tree edit distance algorithm for HHDS trees.
+//
+// Computes the minimum-cost sequence of insert, delete, and relabel operations
+// that transforms one labeled tree into another.
+//
+// Reference: K. Zhang and D. Shasha, "Simple Fast Algorithms for the Editing
+//            Distance between Trees and Related Problems", SIAM J. Comput. 1989.
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <unordered_map>
+#include <vector>
+
+#include "hhds/tree.hpp"
+
+namespace hhds {
+
+struct EditCosts {
+  double insert  = 1.0;  // cost to insert a node (add to T1 to match T2)
+  double del     = 1.0;  // cost to delete a node (remove from T1)
+  double relabel = 1.0;  // cost to relabel a node (change type)
+};
+
+class TreeEditDistance {
+public:
+  struct Result {
+    double distance = 0.0;
+  };
+
+  [[nodiscard]] static Result compute(const Tree::Node_class& root1, const Tree::Node_class& root2,
+                                      const EditCosts&                                                          costs = EditCosts{},
+                                      ::std::function<double(const Tree::Node_class&, const Tree::Node_class&)> cost_fn = nullptr) {
+    TreeEditDistance ted(costs, ::std::move(cost_fn));
+    return Result{ted._run(root1, root2)};
+  }
+// Null or empty trees are treated as empty (zero nodes).
+// distance(empty, empty) = 0
+// distance(empty, T)     = |T| * insert_cost
+// distance(T, empty)     = |T| * delete_cost
+  [[nodiscard]] static Result compute(const ::std::shared_ptr<Tree>& tree1, const ::std::shared_ptr<Tree>& tree2,
+                                      const EditCosts&                                                          costs = EditCosts{},
+                                      ::std::function<double(const Tree::Node_class&, const Tree::Node_class&)> cost_fn = nullptr) {
+    Tree::Node_class root1 = tree1 ? tree1->get_root_node() : Tree::Node_class();
+    Tree::Node_class root2 = tree2 ? tree2->get_root_node() : Tree::Node_class();
+    return compute(root1, root2, costs, ::std::move(cost_fn));
+  }
+
+private:
+  EditCosts                                                                 costs_;
+  ::std::function<double(const Tree::Node_class&, const Tree::Node_class&)> cost_fn_;
+
+  struct TreeData {
+    ::std::vector<Tree::Node_class> nodes;
+    ::std::vector<int>              l;
+    // keyroots: sorted list of post-order indices that are keyroots.
+    // A keyroot is the largest post-order index among all nodes sharing
+    // the same leftmost-leaf value.
+    ::std::vector<int> keyroots;
+  };
+
+  explicit TreeEditDistance(const EditCosts&                                                          costs,
+                            ::std::function<double(const Tree::Node_class&, const Tree::Node_class&)> cost_fn)
+      : costs_(costs), cost_fn_(::std::move(cost_fn)) {}
+
+  [[nodiscard]] double _node_cost(const Tree::Node_class& a, const Tree::Node_class& b) const {
+    if (cost_fn_) {
+      return cost_fn_(a, b);
+    }
+    return (a.get_type() == b.get_type()) ? 0.0 : costs_.relabel;
+  }
+
+  static TreeData _build(const Tree::Node_class& root) {
+    TreeData data;
+    data.nodes.emplace_back();  // sentinel at [0]
+    data.l.push_back(0);        // sentinel at [0]
+
+    ::std::unordered_map<Tree_pos, int> pos_to_idx;
+
+    for (auto node : root.post_order_class()) {
+      const int idx                    = static_cast<int>(data.nodes.size());
+      pos_to_idx[node.get_debug_nid()] = idx;
+
+      int  lval  = idx;  // assume leaf
+      auto first = node.first_child();
+      if (first.is_valid()) {
+        auto it = pos_to_idx.find(first.get_debug_nid());
+        assert(it != pos_to_idx.end() && "post-order invariant violated");
+        lval = data.l[it->second];
+      }
+
+      data.nodes.push_back(node);
+      data.l.push_back(lval);
+    }
+
+    const int n = static_cast<int>(data.nodes.size()) - 1;
+
+    ::std::unordered_map<int, int> lval_to_max_i;
+    for (int i = 1; i <= n; ++i) {
+      lval_to_max_i[data.l[i]] = i;
+    }
+    data.keyroots.reserve(lval_to_max_i.size());
+    for (auto& [lval, i] : lval_to_max_i) {
+      data.keyroots.push_back(i);
+    }
+    ::std::sort(data.keyroots.begin(), data.keyroots.end());
+
+    return data;
+  }
+
+  double _run(const Tree::Node_class& root1, const Tree::Node_class& root2) {
+    if (root1.is_invalid() && root2.is_invalid()) {
+      return 0.0;
+    }
+    if (root1.is_invalid()) {
+      int cnt = 0;
+      for ([[maybe_unused]] auto n : root2.post_order_class()) {
+        ++cnt;
+      }
+      return cnt * costs_.insert;
+    }
+    if (root2.is_invalid()) {
+      int cnt = 0;
+      for ([[maybe_unused]] auto n : root1.post_order_class()) {
+        ++cnt;
+      }
+      return cnt * costs_.del;
+    }
+
+    const TreeData d1 = _build(root1);
+    const TreeData d2 = _build(root2);
+
+    const int n = static_cast<int>(d1.nodes.size()) - 1;
+    const int m = static_cast<int>(d2.nodes.size()) - 1;
+
+    ::std::vector<::std::vector<double>> td(n + 1, ::std::vector<double>(m + 1, 0.0));
+
+    ::std::vector<::std::vector<double>> fd(n + 1, ::std::vector<double>(m + 1, 0.0));
+
+    for (const int i : d1.keyroots) {
+      for (const int j : d2.keyroots) {
+        _forest_dist(d1, d2, i, j, td, fd);
+      }
+    }
+
+    return td[n][m];
+  }
+
+  void _forest_dist(const TreeData& d1, const TreeData& d2, int i, int j, ::std::vector<::std::vector<double>>& td,
+                    ::std::vector<::std::vector<double>>& fd) {
+    const int l1 = d1.l[i];
+    const int l2 = d2.l[j];
+
+    fd[l1 - 1][l2 - 1] = 0.0;
+    for (int i2 = l1; i2 <= i; ++i2) {
+      fd[i2][l2 - 1] = fd[i2 - 1][l2 - 1] + costs_.del;
+    }
+    for (int j2 = l2; j2 <= j; ++j2) {
+      fd[l1 - 1][j2] = fd[l1 - 1][j2 - 1] + costs_.insert;
+    }
+
+    for (int i2 = l1; i2 <= i; ++i2) {
+      for (int j2 = l2; j2 <= j; ++j2) {
+        const double cost_del = fd[i2 - 1][j2] + costs_.del;
+        const double cost_ins = fd[i2][j2 - 1] + costs_.insert;
+
+        if (d1.l[i2] == l1 && d2.l[j2] == l2) {
+          const double cost_match = fd[i2 - 1][j2 - 1] + _node_cost(d1.nodes[i2], d2.nodes[j2]);
+          fd[i2][j2]              = ::std::min({cost_del, cost_ins, cost_match});
+          td[i2][j2]              = fd[i2][j2];
+        } else {
+          const double cost_match = fd[d1.l[i2] - 1][d2.l[j2] - 1] + td[i2][j2];
+          fd[i2][j2]              = ::std::min({cost_del, cost_ins, cost_match});
+        }
+      }
+    }
+  }
+};
+
+}  // namespace hhds


### PR DESCRIPTION
## Summary
Implements the Zhang-Shasha tree edit distance (TED) algorithm for HHDS trees. Given two trees, computes the minimum cost sequence of insert, delete, and relabel operations to transform one into the other.

## Files Added
- `hhds/tree_edit_distance.hpp` — header-only implementation of the algorithm
- `hhds/tests/tree_edit_distance_test.cpp` — test suite verifying correctness

## Implementation Details
- Uses `post_order_class()` iterator from the existing HHDS tree API for post-order traversal
- Computes `l[]` (leftmost leaf) array bottom-up in O(n) using post-order indices
- Keyroots derived from `l[]` to drive the DP loop
- Two DP tables: `td[i][j]` (tree distance, persists across keyroot pairs) and `fd[i][j]` (forest distance, reused per keyroot pair)
- Configurable edit costs (insert, delete, relabel) with default cost 1.0 each
- Optional custom node comparison function via callable

## Tests
All 4 tests pass:
- Identical trees → distance 0
- Single relabel → distance 1
- Single deletion → distance 1
- Single insertion → distance 1

## Reference
K. Zhang and D. Shasha, *Simple Fast Algorithms for the Editing Distance between Trees and Related Problems*, SIAM J. Comput. 1989.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tree edit distance computation using the Zhang–Shasha algorithm with configurable costs (insert, delete, relabel). Supports comparing tree nodes and shared tree references with null-handling.

* **Tests**
  * Added a test executable that verifies distance results across scenarios: identical trees, relabeling, insertion, and deletion; reports outcomes and fails on mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->