### PR TITLE
hhds/graph: cycle-check set_subnode in debug builds

### DIFF
--- a/hhds/graph.cpp
+++ b/hhds/graph.cpp
@@ -1552,6 +1552,13 @@ void Graph::set_subnode(Nid nid, Gid gid) {
     subnode_gio = owner_lib_->graph_ios_[idx].get();
   }
 
+  // Debug-only structural cycle check. Cycles are explicitly disallowed —
+  // they make hier traversal nonsensical (and previously could infinite-loop
+  // fast_hier/forward_hier, which have no runtime guard). Catching at the
+  // call site that creates the cycle gives a localized failure instead of
+  // an infinite loop deep inside an iterator. Compiled out under NDEBUG.
+  assert(!would_create_cycle(gid) && "set_subnode: structure-tree cycle detected");
+
   nid &= ~static_cast<Nid>(3);
   auto pool = get_overflow_pool();
   ref_node(nid)->set_subnode(nid, gid, pool);
@@ -1588,6 +1595,51 @@ void Graph::set_subnode(Nid nid, Gid gid) {
   }
 
   invalidate_traversal_caches();
+}
+
+bool Graph::would_create_cycle(Gid target_gid) const noexcept {
+  if (target_gid == Gid_invalid || self_gid_ == Gid_invalid || owner_lib_ == nullptr) {
+    // Orphan or unbound graphs have no library context to walk; the runtime
+    // active_graphs_ guard in HierIterator covers them as a fallback.
+    return false;
+  }
+  if (target_gid == self_gid_) {
+    return true;  // direct self-instantiation
+  }
+
+  ankerl::unordered_dense::set<Gid> visited;
+  std::vector<Gid>                  stack;
+  stack.push_back(target_gid);
+  while (!stack.empty()) {
+    const Gid current = stack.back();
+    stack.pop_back();
+    if (current == self_gid_) {
+      return true;
+    }
+    if (!visited.insert(current).second) {
+      continue;
+    }
+    if (!owner_lib_->has_graph(current)) {
+      continue;
+    }
+    auto graph = owner_lib_->get_graph(current);
+    if (!graph) {
+      continue;
+    }
+    // Walking subnode_tree_pos_ touches one entry per live submodule
+    // instance (≪ node_table size). Stale entries left by delete_node are
+    // gated by is_alive() + has_subnode() — same defensive check
+    // HierIterator uses.
+    for (const auto& [nid, tree_pos] : graph->subnode_tree_pos_) {
+      (void)tree_pos;
+      const auto* entry = graph->ref_node(nid);
+      if (!entry->is_alive() || !entry->has_subnode()) {
+        continue;
+      }
+      stack.push_back(entry->get_subnode());
+    }
+  }
+  return false;
 }
 
 void Graph::add_edge(Vid driver_id, Vid sink_id) {

--- a/hhds/graph.hpp
+++ b/hhds/graph.hpp
@@ -552,6 +552,12 @@ private:
   [[nodiscard]] std::string_view pin_name(Pin_class pin) const;
   void                           set_subnode(Node_class node, Gid gid);
   void                           set_subnode(Nid nid, Gid gid);
+  // Debug-only structural cycle check used by set_subnode. Returns true iff
+  // making this graph contain an instance of `target_gid` would form a
+  // structure-tree cycle (target_gid transitively contains self_gid_).
+  // BFS over subnode_tree_pos_ entries, so cost scales with hierarchy size,
+  // not graph size. Compiled out under NDEBUG via the call site.
+  [[nodiscard]] bool             would_create_cycle(Gid target_gid) const noexcept;
   void                           add_edge(Pid driver_id, Pid sink_id);
   void add_edge(Pin_class driver_pin, Pin_class sink_pin) { add_edge(driver_pin.get_debug_pid(), sink_pin.get_debug_pid()); }
   void del_edge(Pin_class driver_pin, Pin_class sink_pin);

--- a/hhds/tests/graph_test.cpp
+++ b/hhds/tests/graph_test.cpp
@@ -1,8 +1,12 @@
 #include "hhds/graph.hpp"
 
 #include <cassert>
+#include <csignal>
+#include <fcntl.h>
 #include <iostream>
 #include <string>
+#include <sys/wait.h>
+#include <unistd.h>
 #include <vector>
 
 namespace {
@@ -304,11 +308,13 @@ void test_hier_range_descends_into_nested_subnodes() {
   assert(targets[1] == leaf_gio->get_gid());
 }
 
+#ifdef NDEBUG
 void test_hier_range_cycle_guard() {
-  // Self-referencing submodule must not cause infinite recursion —
-  // active_graphs_ deduplicates on descent. Cycles are disallowed by design
-  // (see todo.md Task 2), but the iterator must be robust in release
-  // builds regardless.
+  // Release-only: structure-tree cycles are blocked at insert time by the
+  // debug assertion in set_subnode (would_create_cycle). When asserts are
+  // off, the runtime guard in HierIterator (active_graphs_) is the sole
+  // line of defense — verify it still terminates on a self-referencing
+  // submodule and doesn't infinite-loop.
   hhds::GraphLibrary lib;
 
   auto self_gio = lib.create_io("self");
@@ -324,6 +330,7 @@ void test_hier_range_cycle_guard() {
   }
   assert(count == 1);
 }
+#endif
 
 void test_hier_range_target_graph_and_parent_node() {
   // get_target_graph() should resolve to the actual body, and
@@ -349,6 +356,139 @@ void test_hier_range_target_graph_and_parent_node() {
   assert(pnode.get_debug_nid() == inst.get_debug_nid());
 }
 
+void test_set_subnode_linear_deep_chain_ok() {
+  // Linear chain a -> b -> c -> d. No cycle, so set_subnode must succeed
+  // at every level. Walking a's hier_range yields 3 instances.
+  hhds::GraphLibrary lib;
+  auto a_gio = lib.create_io("a");
+  auto a     = a_gio->create_graph();
+  auto b_gio = lib.create_io("b");
+  auto b     = b_gio->create_graph();
+  auto c_gio = lib.create_io("c");
+  auto c     = c_gio->create_graph();
+  auto d_gio = lib.create_io("d");
+  (void)d_gio->create_graph();
+
+  a->create_node().set_subnode(b_gio);
+  b->create_node().set_subnode(c_gio);
+  c->create_node().set_subnode(d_gio);
+
+  size_t count = 0;
+  for (auto inst : a->hier_range()) {
+    (void)inst;
+    ++count;
+  }
+  assert(count == 3);
+}
+
+void test_set_subnode_diamond_ok() {
+  // Diamond DAG: top instantiates b1 and b2; both b1 and b2 instantiate
+  // leaf. This is a DAG (leaf is reached two ways), not a cycle —
+  // would_create_cycle must return false for every set_subnode call here.
+  hhds::GraphLibrary lib;
+  auto top_gio  = lib.create_io("top");
+  auto top      = top_gio->create_graph();
+  auto b1_gio   = lib.create_io("b1");
+  auto b1       = b1_gio->create_graph();
+  auto b2_gio   = lib.create_io("b2");
+  auto b2       = b2_gio->create_graph();
+  auto leaf_gio = lib.create_io("leaf");
+  (void)leaf_gio->create_graph();
+
+  top->create_node().set_subnode(b1_gio);
+  top->create_node().set_subnode(b2_gio);
+  b1->create_node().set_subnode(leaf_gio);
+  b2->create_node().set_subnode(leaf_gio);
+
+  // top -> b1 -> leaf, top -> b2 -> leaf : 4 instances total.
+  size_t count = 0;
+  for (auto inst : top->hier_range()) {
+    (void)inst;
+    ++count;
+  }
+  assert(count == 4);
+}
+
+#ifndef NDEBUG
+// Death-test helper: forks, runs `body` in the child, expects the child to
+// die via SIGABRT (the libc assert path). Returns true on the expected
+// outcome. Used to encode "this set_subnode call must trigger the cycle
+// assertion" without aborting the whole test binary.
+template <typename Fn>
+bool expect_assert_abort(Fn body) {
+  pid_t pid = fork();
+  assert(pid >= 0 && "fork failed");
+  if (pid == 0) {
+    // Child: silence assert's stderr noise so the test log stays readable;
+    // we only care about the exit signal, not the message.
+    int devnull = ::open("/dev/null", O_WRONLY);
+    if (devnull >= 0) {
+      ::dup2(devnull, STDERR_FILENO);
+      ::close(devnull);
+    }
+    body();
+    _exit(0);  // body returned without aborting — failure mode
+  }
+  int status = 0;
+  waitpid(pid, &status, 0);
+  return WIFSIGNALED(status) && WTERMSIG(status) == SIGABRT;
+}
+
+void test_set_subnode_self_cycle_aborts() {
+  // Self-instantiation: graph "self" tries to contain an instance of itself.
+  // would_create_cycle short-circuits on target_gid == self_gid_.
+  const bool aborted = expect_assert_abort([]() {
+    hhds::GraphLibrary lib;
+    auto               gio = lib.create_io("self");
+    auto               g   = gio->create_graph();
+    g->create_node().set_subnode(gio);
+  });
+  assert(aborted && "self-cycle did not trigger the set_subnode assertion");
+}
+
+void test_set_subnode_indirect_cycle_aborts() {
+  // Indirect cycle: a contains b, then b tries to contain a. Exercises the
+  // BFS path of would_create_cycle (not just the self-gid short circuit).
+  const bool aborted = expect_assert_abort([]() {
+    hhds::GraphLibrary lib;
+    auto               a_gio = lib.create_io("a");
+    auto               a     = a_gio->create_graph();
+    auto               b_gio = lib.create_io("b");
+    auto               b     = b_gio->create_graph();
+    a->create_node().set_subnode(b_gio);
+    b->create_node().set_subnode(a_gio);
+  });
+  assert(aborted && "indirect cycle did not trigger the set_subnode assertion");
+}
+#endif
+
+void test_set_subnode_retarget_ok() {
+  // Re-calling set_subnode on the same node with a different target must
+  // succeed (no cycle is created — same node, different target). The
+  // structure tree retains a single child for this subnode, retargeted
+  // to the new gid.
+  hhds::GraphLibrary lib;
+  auto a_gio = lib.create_io("a");
+  auto a     = a_gio->create_graph();
+  auto b_gio = lib.create_io("b");
+  (void)b_gio->create_graph();
+  auto c_gio = lib.create_io("c");
+  (void)c_gio->create_graph();
+
+  auto inst = a->create_node();
+  inst.set_subnode(b_gio);
+  inst.set_subnode(c_gio);
+
+  size_t   count       = 0;
+  hhds::Gid last_target = hhds::Gid_invalid;
+  for (auto h : a->hier_range()) {
+    last_target = h.get_target_gid();
+    ++count;
+  }
+  assert(count == 1);
+  assert(last_target == c_gio->get_gid());
+}
+
 }  // namespace
 
 int main() {
@@ -362,8 +502,21 @@ int main() {
   test_hier_range_flat_graph_is_empty();
   test_hier_range_yields_one_per_subnode();
   test_hier_range_descends_into_nested_subnodes();
+#ifdef NDEBUG
+  // In debug builds, set_subnode asserts on the cycle. The runtime
+  // iterator guard is only the active line of defense in release.
   test_hier_range_cycle_guard();
+#endif
   test_hier_range_target_graph_and_parent_node();
+  test_set_subnode_linear_deep_chain_ok();
+  test_set_subnode_diamond_ok();
+  test_set_subnode_retarget_ok();
+#ifndef NDEBUG
+  // Death tests for the cycle assertion. Each forks a child that should
+  // crash inside set_subnode; parent verifies the child died via SIGABRT.
+  test_set_subnode_self_cycle_aborts();
+  test_set_subnode_indirect_cycle_aborts();
+#endif
   std::cout << "graph_test passed\n";
   return 0;
 }

--- a/todo.md
+++ b/todo.md
@@ -4,22 +4,7 @@ Design decisions from recent sessions are captured in `hhds/CLAUDE.md` and
 `~/.claude/projects/-Users-renau-projs-hhds/memory/`. Treat this file as the
 implementation queue.
 
-## 1. Debug-only cycle check in `set_subnode`
-
-**What:** In debug builds, when `set_subnode(node, gid)` is called,
-verify no cycle would be created in the structure tree forest.
-
-**Why:** Cycles are explicitly disallowed (user decision). Without a
-check, a runtime cycle causes infinite loops in hier traversal. Debug-
-only keeps the production path O(1).
-
-**How:** Breadth-first from `gid` through structure-tree subnode refs,
-asserting we never reach `self_gid_`. Visit set keeps the check linear
-in subnode count, which is bounded by hierarchy size (≪ graph size).
-
----
-
-## 2. Optional: eliminate `context_` field entirely
+## 1. Optional: eliminate `context_` field entirely
 
 **What:** Drop `Context context_` and discriminate by field nullity:
 - `root_gid_ == Gid_invalid` → Class
@@ -38,7 +23,7 @@ assignment.
 
 ---
 
-## 3. Optional: `root_graph_` as `Graph*` instead of `Gid`
+## 2. Optional: `root_graph_` as `Graph*` instead of `Gid`
 
 **What:** Store the root as a pointer rather than an id. Parallels how
 `graph_` works.


### PR DESCRIPTION
## Summary

- Adds debug-only structural cycle detection in `Graph::set_subnode`. If the new subnode target would (directly or transitively) contain `self_gid_`, an `assert` fires at the call site with the message `"set_subnode: structure-tree cycle detected"`.
- Detection runs via `Graph::would_create_cycle(Gid target_gid)` — a BFS over `subnode_tree_pos_` of each visited graph, gated on `is_alive() && has_subnode()` (same defensive filter `HierIterator` uses for stale tombstones). Cost is O(hierarchy size), not O(graph size). Compiled out under `NDEBUG`.
- Localizes the failure: previously a structural cycle silently passed `set_subnode`, then either infinite-looped `fast_hier`/`forward_hier` (no runtime guard) or yielded once-and-stop in `hier_range` (active_graphs guard). Now the call that creates the cycle asserts immediately.
- Existing `test_hier_range_cycle_guard` is now wrapped in `#ifdef NDEBUG` — in debug builds the cycle is blocked at insert time; the iterator's runtime guard remains the active line of defense in release.

Implements task 1 from `todo.md`.

## Test plan

- [x] `bazel test //hhds:all` — 14/14 pass, including the 5 contract tests (untouched).
- [x] New positive cases in `hhds/tests/graph_test.cpp`:
  - [x] linear chain `a → b → c → d` (depth-3 hierarchy, no cycle)
  - [x] diamond DAG `top → {b1, b2} → leaf` (`leaf` reached via two paths, still acyclic)
  - [x] retarget — calling `set_subnode` twice on the same node with different targets keeps the structure tree to one entry
- [x] New death tests (POSIX, `#ifndef NDEBUG`-only) using a fork-based `expect_assert_abort` helper:
  - [x] self-cycle: a graph instantiates its own `GraphIO`
  - [x] indirect cycle: `a → b`, then `b → a` triggers the BFS-path assertion
- [x] Manual smoke run of a standalone cycle-creating binary produced `Assertion failed: ... structure-tree cycle detected` exactly at `set_subnode`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented structural cycle detection in graph hierarchies to prevent invalid circular references and maintain data integrity during development and debugging.

* **Tests**
  * Added comprehensive test coverage for graph hierarchy operations, including linear dependency chains, multi-parent hierarchies, node reassignment, and various cycle detection edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->