### PR TITLE
Add backward topological iterators to hhds graph

### DIFF
--- a/hhds/bench/.gitignore
+++ b/hhds/bench/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+results/
+*.png
+*.pdf
+__pycache__/

--- a/hhds/bench/BUILD.bazel
+++ b/hhds/bench/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//tools:copt_default.bzl", "COPTS")
+
+cc_library(
+    name = "graph_spec",
+    srcs = ["generator/graph_spec.cpp"],
+    hdrs = ["generator/graph_spec.hpp"],
+    copts = COPTS,
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)
+
+cc_binary(
+    name = "hhds_bench",
+    srcs = ["hhds_bench.cpp"],
+    copts = COPTS + [
+        "-Wno-unused-parameter",
+        "-Wno-unused-variable",
+        "-Wno-shadow",
+    ],
+    tags = ["manual"],
+    deps = [
+        ":graph_spec",
+        "//hhds:graph",
+        "@google_benchmark//:benchmark",
+    ],
+)

--- a/hhds/bench/generator/graph_spec.cpp
+++ b/hhds/bench/generator/graph_spec.cpp
@@ -1,0 +1,134 @@
+#include "graph_spec.hpp"
+
+#include <cassert>
+#include <random>
+
+namespace hhds_bench {
+
+Topology parse_topology(std::string_view name) {
+  if (name == "chain") {
+    return Topology::Chain;
+  }
+  if (name == "fanout") {
+    return Topology::Fanout;
+  }
+  if (name == "random_dag") {
+    return Topology::RandomDag;
+  }
+  if (name == "eda_typical") {
+    return Topology::EdaTypical;
+  }
+  assert(false && "unknown topology");
+  return Topology::Chain;
+}
+
+std::string_view topology_name(Topology t) {
+  switch (t) {
+    case Topology::Chain:      return "chain";
+    case Topology::Fanout:     return "fanout";
+    case Topology::RandomDag:  return "random_dag";
+    case Topology::EdaTypical: return "eda_typical";
+  }
+  return "unknown";
+}
+
+namespace {
+
+EdgeList make_chain(const GraphSpec& spec) {
+  EdgeList out;
+  out.nodes = spec.nodes;
+  out.edges.reserve(static_cast<size_t>(std::max(0, spec.nodes - 1)));
+  for (int i = 0; i + 1 < spec.nodes; ++i) {
+    out.edges.emplace_back(i, i + 1);
+  }
+  return out;
+}
+
+EdgeList make_fanout(const GraphSpec& spec) {
+  EdgeList out;
+  out.nodes = spec.nodes;
+  out.edges.reserve(static_cast<size_t>(std::max(0, 2 * spec.nodes)));
+  for (int i = 0; i < spec.nodes; ++i) {
+    const int left  = 2 * i + 1;
+    const int right = 2 * i + 2;
+    if (left < spec.nodes) {
+      out.edges.emplace_back(i, left);
+    }
+    if (right < spec.nodes) {
+      out.edges.emplace_back(i, right);
+    }
+  }
+  return out;
+}
+
+EdgeList make_random_dag(const GraphSpec& spec) {
+  EdgeList out;
+  out.nodes = spec.nodes;
+  std::mt19937_64                 rng(spec.seed);
+  std::uniform_int_distribution<> count_dist(1, std::max(1, spec.fanout_max));
+  out.edges.reserve(static_cast<size_t>(spec.nodes) * static_cast<size_t>(spec.fanout_max));
+  for (int i = 0; i < spec.nodes; ++i) {
+    const int max_targets = std::min(spec.nodes - 1 - i, spec.fanout_max);
+    if (max_targets <= 0) {
+      continue;
+    }
+    const int                       k = std::min(count_dist(rng), max_targets);
+    std::uniform_int_distribution<> target_dist(i + 1, spec.nodes - 1);
+    for (int e = 0; e < k; ++e) {
+      out.edges.emplace_back(i, target_dist(rng));
+    }
+  }
+  return out;
+}
+
+EdgeList make_eda_typical(const GraphSpec& spec) {
+  // Mostly-pin-0 chain backbone (90% of edges) + 10% sparse cross-edges
+  // skipping ahead 2-8 nodes. Mimics LUT/gate netlist where most signals
+  // are register-to-register short hops with occasional bypass paths.
+  EdgeList out;
+  out.nodes = spec.nodes;
+  out.edges.reserve(static_cast<size_t>(spec.nodes));
+  std::mt19937_64                 rng(spec.seed);
+  std::uniform_int_distribution<> skip_dist(2, 8);
+  std::uniform_real_distribution<> coin(0.0, 1.0);
+  for (int i = 0; i + 1 < spec.nodes; ++i) {
+    out.edges.emplace_back(i, i + 1);
+    if (coin(rng) < 0.1) {
+      const int target = i + skip_dist(rng);
+      if (target < spec.nodes) {
+        out.edges.emplace_back(i, target);
+      }
+    }
+  }
+  return out;
+}
+
+}  // namespace
+
+EdgeList make_edge_list(const GraphSpec& spec) {
+  switch (spec.topology) {
+    case Topology::Chain:      return make_chain(spec);
+    case Topology::Fanout:     return make_fanout(spec);
+    case Topology::RandomDag:  return make_random_dag(spec);
+    case Topology::EdaTypical: return make_eda_typical(spec);
+  }
+  return {};
+}
+
+PinAssignment make_pin_assignment(const GraphSpec& spec, const EdgeList& edges) {
+  PinAssignment out;
+  if (spec.pins_per_node <= 1) {
+    return out;
+  }
+  out.driver_ports.reserve(edges.edges.size());
+  out.sink_ports.reserve(edges.edges.size());
+  std::mt19937_64                 rng(spec.seed ^ 0x9E3779B97F4A7C15ULL);
+  std::uniform_int_distribution<> port_dist(0, spec.pins_per_node - 1);
+  for (size_t i = 0; i < edges.edges.size(); ++i) {
+    out.driver_ports.push_back(port_dist(rng));
+    out.sink_ports.push_back(port_dist(rng));
+  }
+  return out;
+}
+
+}  // namespace hhds_bench

--- a/hhds/bench/generator/graph_spec.cpp
+++ b/hhds/bench/generator/graph_spec.cpp
@@ -18,16 +18,28 @@ Topology parse_topology(std::string_view name) {
   if (name == "eda_typical") {
     return Topology::EdaTypical;
   }
+  if (name == "dense") {
+    return Topology::Dense;
+  }
+  if (name == "sedges_only") {
+    return Topology::SedgesOnly;
+  }
+  if (name == "overflow_only") {
+    return Topology::OverflowOnly;
+  }
   assert(false && "unknown topology");
   return Topology::Chain;
 }
 
 std::string_view topology_name(Topology t) {
   switch (t) {
-    case Topology::Chain:      return "chain";
-    case Topology::Fanout:     return "fanout";
-    case Topology::RandomDag:  return "random_dag";
-    case Topology::EdaTypical: return "eda_typical";
+    case Topology::Chain:        return "chain";
+    case Topology::Fanout:       return "fanout";
+    case Topology::RandomDag:    return "random_dag";
+    case Topology::EdaTypical:   return "eda_typical";
+    case Topology::Dense:        return "dense";
+    case Topology::SedgesOnly:   return "sedges_only";
+    case Topology::OverflowOnly: return "overflow_only";
   }
   return "unknown";
 }
@@ -81,6 +93,42 @@ EdgeList make_random_dag(const GraphSpec& spec) {
   return out;
 }
 
+// Helper: each node connects to the next K nodes (forward, capped at N-1).
+// Result: middle nodes have ~K incoming + ~K outgoing edges = ~2K total.
+EdgeList make_forward_k(const GraphSpec& spec, int k) {
+  EdgeList out;
+  out.nodes = spec.nodes;
+  out.edges.reserve(static_cast<size_t>(spec.nodes) * k);
+  for (int i = 0; i < spec.nodes; ++i) {
+    const int last = std::min(i + k, spec.nodes - 1);
+    for (int j = i + 1; j <= last; ++j) {
+      out.edges.emplace_back(i, j);
+    }
+  }
+  return out;
+}
+
+EdgeList make_dense(const GraphSpec& spec) {
+  // 32 forward edges per node -> middle nodes have ~64 total edges,
+  // well past the 10-edge node-overflow threshold.
+  return make_forward_k(spec, 32);
+}
+
+EdgeList make_sedges_only(const GraphSpec& spec) {
+  // 2 forward edges per node -> middle nodes have ~4 total edges
+  // (2 in + 2 out), all of which fit in the 4-slot sedges_ packed
+  // path. No overflow, no ledge slots, no sedges_extra.
+  return make_forward_k(spec, 2);
+}
+
+EdgeList make_overflow_only(const GraphSpec& spec) {
+  // 16 forward edges per node -> middle nodes have ~32 total edges,
+  // well past the 10-edge node-overflow threshold. When overflow is
+  // first triggered hhds flushes all inline content into the overflow
+  // set, so every node's edges live entirely in overflow.
+  return make_forward_k(spec, 16);
+}
+
 EdgeList make_eda_typical(const GraphSpec& spec) {
   // Mostly-pin-0 chain backbone (90% of edges) + 10% sparse cross-edges
   // skipping ahead 2-8 nodes. Mimics LUT/gate netlist where most signals
@@ -107,10 +155,13 @@ EdgeList make_eda_typical(const GraphSpec& spec) {
 
 EdgeList make_edge_list(const GraphSpec& spec) {
   switch (spec.topology) {
-    case Topology::Chain:      return make_chain(spec);
-    case Topology::Fanout:     return make_fanout(spec);
-    case Topology::RandomDag:  return make_random_dag(spec);
-    case Topology::EdaTypical: return make_eda_typical(spec);
+    case Topology::Chain:        return make_chain(spec);
+    case Topology::Fanout:       return make_fanout(spec);
+    case Topology::RandomDag:    return make_random_dag(spec);
+    case Topology::EdaTypical:   return make_eda_typical(spec);
+    case Topology::Dense:        return make_dense(spec);
+    case Topology::SedgesOnly:   return make_sedges_only(spec);
+    case Topology::OverflowOnly: return make_overflow_only(spec);
   }
   return {};
 }

--- a/hhds/bench/generator/graph_spec.hpp
+++ b/hhds/bench/generator/graph_spec.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace hhds_bench {
+
+enum class Topology {
+  Chain,        // 0 -> 1 -> 2 -> ... -> N-1
+  Fanout,       // Binary tree: i drives 2i+1, 2i+2 (capped at N-1)
+  RandomDag,    // Each node i has up to fanout_max edges to j > i, drawn deterministically from seed
+  EdaTypical,   // Mostly-pin-0 chain backbone + sparse cross-edges; mimics typical netlist
+};
+
+[[nodiscard]] Topology parse_topology(std::string_view name);
+[[nodiscard]] std::string_view topology_name(Topology t);
+
+struct GraphSpec {
+  int      nodes         = 1000;
+  int      pins_per_node = 1;       // 1 = pin-0 only on hhds
+  int      hier_size     = 1;       // 1 = single graph; >1 = top with N submodule instances
+  int      fanout_max    = 4;       // mean out-degree for RandomDag / EdaTypical
+  uint64_t seed          = 0xC0FFEEULL;
+  Topology topology      = Topology::Chain;
+};
+
+// Edge list in node-index space. Both endpoints are in [0, spec.nodes).
+// Generated deterministically from spec.seed.
+struct EdgeList {
+  std::vector<std::pair<int, int>> edges;
+  int nodes = 0;
+};
+
+[[nodiscard]] EdgeList make_edge_list(const GraphSpec& spec);
+
+// Pin assignment: for each edge, which port (0..pins_per_node-1) the
+// driver uses on its source node, and which port the sink uses on its
+// destination node. Same seed -> identical pin assignment across libs.
+//
+// Returned vectors are parallel to edges. Empty if spec.pins_per_node <= 1
+// (everything stays on pin 0, the default).
+struct PinAssignment {
+  std::vector<int> driver_ports;
+  std::vector<int> sink_ports;
+};
+
+[[nodiscard]] PinAssignment make_pin_assignment(const GraphSpec& spec, const EdgeList& edges);
+
+}  // namespace hhds_bench

--- a/hhds/bench/generator/graph_spec.hpp
+++ b/hhds/bench/generator/graph_spec.hpp
@@ -8,10 +8,27 @@
 namespace hhds_bench {
 
 enum class Topology {
-  Chain,        // 0 -> 1 -> 2 -> ... -> N-1
-  Fanout,       // Binary tree: i drives 2i+1, 2i+2 (capped at N-1)
+  Chain,        // 0 -> 1 -> 2 -> ... -> N-1   (1 edge/node — never overflows)
+  Fanout,       // Binary tree: i drives 2i+1, 2i+2 (capped at N-1) — never overflows
   RandomDag,    // Each node i has up to fanout_max edges to j > i, drawn deterministically from seed
   EdaTypical,   // Mostly-pin-0 chain backbone + sparse cross-edges; mimics typical netlist
+  Dense,        // Each node connects to next 32 nodes; deprecated alias for OverflowOnly
+                // with extra connectivity. Kept for back-compat with earlier sweeps.
+  // --- Inline-vs-overflow comparison topologies ---
+  // hhds NodeEntry has a 3-tier inline budget before overflow:
+  //   slots 1-4   sedges_ packed (fastest)
+  //   slots 5-7   sedges_extra packed
+  //   slots 8-9   ledge0/ledge1 (long edges)
+  //   slot 10+    overflow_handling() -> hashset
+  // PinEntry is similar but lacks sedges_extra: tier boundary is 4 / 6 / 7+.
+  SedgesOnly,    // Each node connects to next 2 nodes -> middle nodes have ~4 total edges
+                 // (2 in + 2 out), all fitting in the 4-slot sedges_ packed path.
+                 // Pure fastest-path benchmark.
+  OverflowOnly,  // Each node connects to next 16 nodes -> middle nodes have ~32 total
+                 // edges (16 in + 16 out), well past the 10-edge overflow trigger.
+                 // When overflow is first triggered, hhds flushes the inline tier into
+                 // the overflow set, so all edges end up in overflow with no inline
+                 // content remaining — a clean "overflow-only" benchmark.
 };
 
 [[nodiscard]] Topology parse_topology(std::string_view name);

--- a/hhds/bench/hhds_bench.cpp
+++ b/hhds/bench/hhds_bench.cpp
@@ -1,0 +1,521 @@
+// Comparison bench for hhds. Same CLI and CSV schema as
+// boost_bench / lgraph_bench_thesis. See bench/schema.md for the column
+// contract; the run_all.sh wrapper fills in the memory/perf columns
+// externally.
+
+#include <benchmark/benchmark.h>
+
+#include <cassert>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "generator/graph_spec.hpp"
+#include "graph.hpp"
+
+namespace {
+
+struct CliArgs {
+  std::string         op           = "build_node";
+  std::string         topology     = "chain";
+  std::string         axis         = "nodes";
+  int                 nodes        = 1000;
+  int                 pins         = 1;
+  int                 hier         = 1;
+  int                 fanout_max   = 4;
+  uint64_t            seed         = 0xC0FFEEULL;
+  int                 runs         = 5;
+  bool                emit_header  = true;  // false to append to a master CSV
+  bool                verify       = false; // print visited count to stderr per run
+};
+
+// Global: set once by CLI parsing, read by each op AFTER its timer stops.
+// Kept off the hot path so verification mode doesn't perturb measurements.
+bool g_verify = false;
+
+struct OpResult {
+  int64_t wall_ns;
+  int64_t visited;  // for build_*/add_pin/mutate/lookup: items processed; for traverse_*: nodes/instances visited
+};
+
+CliArgs parse_args(int argc, char** argv) {
+  CliArgs a;
+  for (int i = 1; i < argc; ++i) {
+    std::string_view s = argv[i];
+    auto eat = [&](std::string_view prefix, std::string& dst) -> bool {
+      if (s.rfind(prefix, 0) == 0) {
+        dst = std::string(s.substr(prefix.size()));
+        return true;
+      }
+      return false;
+    };
+    auto eat_int = [&](std::string_view prefix, int& dst) -> bool {
+      std::string buf;
+      if (!eat(prefix, buf)) {
+        return false;
+      }
+      dst = std::atoi(buf.c_str());
+      return true;
+    };
+    auto eat_u64 = [&](std::string_view prefix, uint64_t& dst) -> bool {
+      std::string buf;
+      if (!eat(prefix, buf)) {
+        return false;
+      }
+      dst = std::strtoull(buf.c_str(), nullptr, 0);
+      return true;
+    };
+    if (eat("--op=", a.op)) continue;
+    if (eat("--topology=", a.topology)) continue;
+    if (eat("--axis=", a.axis)) continue;
+    if (eat_int("--nodes=", a.nodes)) continue;
+    if (eat_int("--pins=", a.pins)) continue;
+    if (eat_int("--hier=", a.hier)) continue;
+    if (eat_int("--fanout=", a.fanout_max)) continue;
+    if (eat_u64("--seed=", a.seed)) continue;
+    if (eat_int("--runs=", a.runs)) continue;
+    if (s == "--no-header") {
+      a.emit_header = false;
+      continue;
+    }
+    if (s == "--verify") {
+      a.verify = true;
+      continue;
+    }
+    std::cerr << "hhds_bench: unknown arg: " << s << "\n";
+    std::exit(2);
+  }
+  return a;
+}
+
+hhds_bench::GraphSpec spec_from(const CliArgs& a) {
+  hhds_bench::GraphSpec s;
+  s.nodes         = a.nodes;
+  s.pins_per_node = a.pins;
+  s.hier_size     = a.hier;
+  s.fanout_max    = a.fanout_max;
+  s.seed          = a.seed;
+  s.topology      = hhds_bench::parse_topology(a.topology);
+  return s;
+}
+
+// Materialize one (flat, single-graph) hhds Graph from an EdgeList +
+// PinAssignment. Returns the graph plus the index->Node table so callers
+// can do further work (mutate, lookup) without re-walking node_table.
+struct BuiltGraph {
+  hhds::GraphLibrary           lib;
+  std::shared_ptr<hhds::Graph> graph;
+  std::vector<hhds::Node>      nodes;
+};
+
+void materialize_flat(BuiltGraph& bg, const hhds_bench::GraphSpec& spec, const hhds_bench::EdgeList& edges,
+                      const hhds_bench::PinAssignment& pins) {
+  auto gio = bg.lib.create_io("top");
+  gio->add_input("in", 0);
+  gio->add_output("out", 0);
+  bg.graph = gio->create_graph();
+
+  bg.nodes.reserve(static_cast<size_t>(spec.nodes));
+  for (int i = 0; i < spec.nodes; ++i) {
+    bg.nodes.push_back(bg.graph->create_node());
+  }
+
+  // Edges are added even when the bench measures only build_node — callers
+  // pass an empty edges.edges to skip this loop.
+  for (size_t i = 0; i < edges.edges.size(); ++i) {
+    const auto [src, dst] = edges.edges[i];
+    if (pins.driver_ports.empty()) {
+      // Pin-0 fast path: hhds avoids creating a separate pin entry.
+      bg.nodes[src].create_driver_pin().connect_sink(bg.nodes[dst].create_sink_pin());
+    } else {
+      const auto dport = static_cast<hhds::Port_id>(pins.driver_ports[i]);
+      const auto sport = static_cast<hhds::Port_id>(pins.sink_ports[i]);
+      bg.nodes[src].create_driver_pin(dport).connect_sink(bg.nodes[dst].create_sink_pin(sport));
+    }
+  }
+
+  // Anchor first/last to the declared graph in/out so iterators have real
+  // sources/sinks. Without this, every node looks like a source to the
+  // forward iterator and Pass-1 emits everything immediately.
+  if (spec.nodes > 0) {
+    bg.graph->get_input_pin("in").connect_sink(bg.nodes[0].create_sink_pin());
+    if (!edges.edges.empty()) {
+      bg.nodes[spec.nodes - 1].create_driver_pin().connect_sink(bg.graph->get_output_pin("out"));
+    }
+  }
+}
+
+// --- Operations ---
+
+// Helper: compute (t1-t0) in nanoseconds.
+inline int64_t ns_between(std::chrono::steady_clock::time_point t0, std::chrono::steady_clock::time_point t1) {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+}
+
+OpResult op_build_node(const hhds_bench::GraphSpec& spec) {
+  auto t0 = std::chrono::steady_clock::now();
+  hhds::GraphLibrary lib;
+  auto               gio = lib.create_io("top");
+  auto               g   = gio->create_graph();
+  int64_t            built = 0;
+  for (int i = 0; i < spec.nodes; ++i) {
+    auto n = g->create_node();
+    benchmark::DoNotOptimize(n);
+    ++built;
+  }
+  auto t1 = std::chrono::steady_clock::now();
+  return {ns_between(t0, t1), built};
+}
+
+OpResult op_build_edges(const hhds_bench::GraphSpec& spec) {
+  // Build nodes first (untimed), then time only the edge insertion phase.
+  hhds_bench::EdgeList      edges = hhds_bench::make_edge_list(spec);
+  hhds_bench::PinAssignment pins  = hhds_bench::make_pin_assignment(spec, edges);
+  BuiltGraph                bg;
+  auto                      gio = bg.lib.create_io("top");
+  gio->add_input("in", 0);
+  gio->add_output("out", 0);
+  bg.graph = gio->create_graph();
+  bg.nodes.reserve(static_cast<size_t>(spec.nodes));
+  for (int i = 0; i < spec.nodes; ++i) {
+    bg.nodes.push_back(bg.graph->create_node());
+  }
+  if (spec.nodes > 0) {
+    bg.graph->get_input_pin("in").connect_sink(bg.nodes[0].create_sink_pin());
+  }
+
+  auto    t0      = std::chrono::steady_clock::now();
+  int64_t added   = 0;
+  for (size_t i = 0; i < edges.edges.size(); ++i) {
+    const auto [src, dst] = edges.edges[i];
+    if (pins.driver_ports.empty()) {
+      bg.nodes[src].create_driver_pin().connect_sink(bg.nodes[dst].create_sink_pin());
+    } else {
+      const auto dport = static_cast<hhds::Port_id>(pins.driver_ports[i]);
+      const auto sport = static_cast<hhds::Port_id>(pins.sink_ports[i]);
+      bg.nodes[src].create_driver_pin(dport).connect_sink(bg.nodes[dst].create_sink_pin(sport));
+    }
+    ++added;
+  }
+  auto t1 = std::chrono::steady_clock::now();
+  return {ns_between(t0, t1), added};
+}
+
+OpResult op_traverse_forward_class(const hhds_bench::GraphSpec& spec) {
+  hhds_bench::EdgeList      edges = hhds_bench::make_edge_list(spec);
+  hhds_bench::PinAssignment pins  = hhds_bench::make_pin_assignment(spec, edges);
+  BuiltGraph                bg;
+  materialize_flat(bg, spec, edges, pins);
+
+  auto    t0    = std::chrono::steady_clock::now();
+  int64_t count = 0;
+  for (auto node : bg.graph->forward_class()) {
+    benchmark::DoNotOptimize(node);
+    ++count;
+  }
+  auto t1 = std::chrono::steady_clock::now();
+  benchmark::DoNotOptimize(count);
+  return {ns_between(t0, t1), count};
+}
+
+OpResult op_traverse_fast_class(const hhds_bench::GraphSpec& spec) {
+  hhds_bench::EdgeList      edges = hhds_bench::make_edge_list(spec);
+  hhds_bench::PinAssignment pins  = hhds_bench::make_pin_assignment(spec, edges);
+  BuiltGraph                bg;
+  materialize_flat(bg, spec, edges, pins);
+
+  auto    t0    = std::chrono::steady_clock::now();
+  int64_t count = 0;
+  for (auto node : bg.graph->fast_class()) {
+    benchmark::DoNotOptimize(node);
+    ++count;
+  }
+  auto t1 = std::chrono::steady_clock::now();
+  benchmark::DoNotOptimize(count);
+  return {ns_between(t0, t1), count};
+}
+
+// Build top-level graph with spec.hier_size instances of one shared
+// chain subgraph (spec.nodes inner nodes each). Returns the top graph;
+// the GraphLibrary stays alive in `lib` (move-pinned, so callers must
+// pass an existing BuiltGraph). Used by every hier traversal op so the
+// build cost is identical across forward_flat/fast_flat/forward_hier/
+// fast_hier/hier_range comparisons.
+std::shared_ptr<hhds::Graph> materialize_hier(hhds::GraphLibrary& lib, const hhds_bench::GraphSpec& spec) {
+  auto sub_gio = lib.create_io("sub");
+  sub_gio->add_input("i", 0);
+  sub_gio->add_output("o", 0);
+  auto sub = sub_gio->create_graph();
+  std::vector<hhds::Node> inner;
+  inner.reserve(static_cast<size_t>(spec.nodes));
+  for (int i = 0; i < spec.nodes; ++i) {
+    inner.push_back(sub->create_node());
+  }
+  if (spec.nodes > 0) {
+    sub->get_input_pin("i").connect_sink(inner[0].create_sink_pin());
+    for (int i = 0; i + 1 < spec.nodes; ++i) {
+      inner[i].create_driver_pin().connect_sink(inner[i + 1].create_sink_pin());
+    }
+    inner[spec.nodes - 1].create_driver_pin().connect_sink(sub->get_output_pin("o"));
+  }
+
+  auto top_gio = lib.create_io("top");
+  top_gio->add_input("in", 0);
+  top_gio->add_output("out", 0);
+  auto top = top_gio->create_graph();
+  std::vector<hhds::Node> inst;
+  inst.reserve(static_cast<size_t>(spec.hier_size));
+  for (int i = 0; i < spec.hier_size; ++i) {
+    auto n = top->create_node();
+    n.set_subnode(sub_gio);
+    inst.push_back(n);
+  }
+  if (spec.hier_size > 0) {
+    top->get_input_pin("in").connect_sink(inst[0].create_sink_pin("i"));
+    for (int i = 0; i + 1 < spec.hier_size; ++i) {
+      inst[i].create_driver_pin("o").connect_sink(inst[i + 1].create_sink_pin("i"));
+    }
+    inst[spec.hier_size - 1].create_driver_pin("o").connect_sink(top->get_output_pin("out"));
+  }
+  return top;
+}
+
+OpResult op_traverse_forward_flat(const hhds_bench::GraphSpec& spec) {
+  hhds::GraphLibrary lib;
+  auto               top = materialize_hier(lib, spec);
+
+  auto    t0    = std::chrono::steady_clock::now();
+  int64_t count = 0;
+  for (auto node : top->forward_flat()) {
+    benchmark::DoNotOptimize(node);
+    ++count;
+  }
+  auto t1 = std::chrono::steady_clock::now();
+  benchmark::DoNotOptimize(count);
+  return {ns_between(t0, t1), count};
+}
+
+OpResult op_traverse_fast_flat(const hhds_bench::GraphSpec& spec) {
+  hhds::GraphLibrary lib;
+  auto               top = materialize_hier(lib, spec);
+
+  auto    t0    = std::chrono::steady_clock::now();
+  int64_t count = 0;
+  for (auto node : top->fast_flat()) {
+    benchmark::DoNotOptimize(node);
+    ++count;
+  }
+  auto t1 = std::chrono::steady_clock::now();
+  benchmark::DoNotOptimize(count);
+  return {ns_between(t0, t1), count};
+}
+
+// op_add_pin: build N empty nodes (untimed), then time creating
+// spec.pins_per_node driver pins + spec.pins_per_node sink pins on each
+// node. Pins are created with explicit Port_id 0..K-1 so we exercise
+// hhds's three storage regimes (inline -> overflow array -> emhash8 set)
+// as the count crosses the 16/64 thresholds documented in graph.hpp:74.
+OpResult op_add_pin(const hhds_bench::GraphSpec& spec) {
+  hhds::GraphLibrary lib;
+  auto               gio = lib.create_io("top");
+  auto               g   = gio->create_graph();
+  std::vector<hhds::Node> nodes;
+  nodes.reserve(static_cast<size_t>(spec.nodes));
+  for (int i = 0; i < spec.nodes; ++i) {
+    nodes.push_back(g->create_node());
+  }
+
+  const int K = std::max(1, spec.pins_per_node);
+
+  auto    t0      = std::chrono::steady_clock::now();
+  int64_t pin_cnt = 0;
+  for (int i = 0; i < spec.nodes; ++i) {
+    for (int p = 0; p < K; ++p) {
+      auto dp = nodes[i].create_driver_pin(static_cast<hhds::Port_id>(p));
+      auto sp = nodes[i].create_sink_pin(static_cast<hhds::Port_id>(p));
+      benchmark::DoNotOptimize(dp);
+      benchmark::DoNotOptimize(sp);
+      pin_cnt += 2;
+    }
+  }
+  auto t1 = std::chrono::steady_clock::now();
+  return {ns_between(t0, t1), pin_cnt};
+}
+
+OpResult op_traverse_forward_hier(const hhds_bench::GraphSpec& spec) {
+  hhds::GraphLibrary lib;
+  auto               top = materialize_hier(lib, spec);
+
+  auto    t0    = std::chrono::steady_clock::now();
+  int64_t count = 0;
+  for (auto node : top->forward_hier()) {
+    benchmark::DoNotOptimize(node);
+    ++count;
+  }
+  auto t1 = std::chrono::steady_clock::now();
+  benchmark::DoNotOptimize(count);
+  return {ns_between(t0, t1), count};
+}
+
+OpResult op_traverse_fast_hier(const hhds_bench::GraphSpec& spec) {
+  hhds::GraphLibrary lib;
+  auto               top = materialize_hier(lib, spec);
+
+  auto    t0    = std::chrono::steady_clock::now();
+  int64_t count = 0;
+  for (auto node : top->fast_hier()) {
+    benchmark::DoNotOptimize(node);
+    ++count;
+  }
+  auto t1 = std::chrono::steady_clock::now();
+  benchmark::DoNotOptimize(count);
+  return {ns_between(t0, t1), count};
+}
+
+// op_traverse_hier_range: instance-only walk. Yields one entry per
+// submodule instance (cost proportional to hier size, not graph node
+// count) — distinct from fast_hier/forward_hier which visit every graph
+// node within every instance.
+OpResult op_traverse_hier_range(const hhds_bench::GraphSpec& spec) {
+  hhds::GraphLibrary lib;
+  auto               top = materialize_hier(lib, spec);
+
+  auto    t0    = std::chrono::steady_clock::now();
+  int64_t count = 0;
+  for (auto inst : top->hier_range()) {
+    benchmark::DoNotOptimize(inst);
+    ++count;
+  }
+  auto t1 = std::chrono::steady_clock::now();
+  benchmark::DoNotOptimize(count);
+  return {ns_between(t0, t1), count};
+}
+
+// op_mutate: build full graph (untimed), then time deletion of a 10%
+// random sample of nodes. Deletion is tombstone-based in hhds — IDs are
+// never reused — so this measures the per-deletion bookkeeping cost.
+OpResult op_mutate(const hhds_bench::GraphSpec& spec) {
+  hhds_bench::EdgeList      edges = hhds_bench::make_edge_list(spec);
+  hhds_bench::PinAssignment pins  = hhds_bench::make_pin_assignment(spec, edges);
+  BuiltGraph                bg;
+  materialize_flat(bg, spec, edges, pins);
+
+  // Pick a 10% deletion sample WITHOUT replacement (partial Fisher-Yates
+  // shuffle). hhds asserts on double-delete, so the bench must not draw
+  // the same victim twice. Skip the first/last node so the
+  // connect-to-graph-IO anchors stay valid.
+  const int       sample = std::max(1, spec.nodes / 10);
+  const int       lo     = 1;
+  const int       hi     = std::max(lo + 1, spec.nodes - 1);
+  const int       pool   = hi - lo;
+  std::mt19937_64 rng(spec.seed ^ 0xDEADBEEFULL);
+  std::vector<int> indices;
+  indices.reserve(static_cast<size_t>(pool));
+  for (int i = 0; i < pool; ++i) {
+    indices.push_back(lo + i);
+  }
+  const int picks = std::min(sample, pool);
+  for (int i = 0; i < picks; ++i) {
+    std::uniform_int_distribution<> swap_dist(i, pool - 1);
+    std::swap(indices[i], indices[swap_dist(rng)]);
+  }
+  indices.resize(static_cast<size_t>(picks));
+
+  auto    t0      = std::chrono::steady_clock::now();
+  int64_t deleted = 0;
+  for (int v : indices) {
+    bg.nodes[v].del_node();
+    ++deleted;
+  }
+  auto t1 = std::chrono::steady_clock::now();
+  return {ns_between(t0, t1), deleted};
+}
+
+// op_lookup: build full graph (untimed), pre-pick spec.nodes random
+// class indexes, then time graph->get_node(idx) calls. Sanity check —
+// expected to be O(1) per call regardless of N.
+OpResult op_lookup(const hhds_bench::GraphSpec& spec) {
+  hhds_bench::EdgeList      edges = hhds_bench::make_edge_list(spec);
+  hhds_bench::PinAssignment pins  = hhds_bench::make_pin_assignment(spec, edges);
+  BuiltGraph                bg;
+  materialize_flat(bg, spec, edges, pins);
+
+  std::mt19937_64                 rng(spec.seed ^ 0xBADCAFEULL);
+  std::uniform_int_distribution<> idx_dist(0, std::max(0, spec.nodes - 1));
+  std::vector<hhds::Class_index>  keys;
+  keys.reserve(static_cast<size_t>(spec.nodes));
+  for (int i = 0; i < spec.nodes; ++i) {
+    keys.push_back(bg.nodes[idx_dist(rng)].get_class_index());
+  }
+
+  auto    t0       = std::chrono::steady_clock::now();
+  int64_t resolved = 0;
+  for (const auto& k : keys) {
+    auto n = bg.graph->get_node(k);
+    benchmark::DoNotOptimize(n);
+    ++resolved;
+  }
+  auto t1 = std::chrono::steady_clock::now();
+  return {ns_between(t0, t1), resolved};
+}
+
+OpResult dispatch(const std::string& op, const hhds_bench::GraphSpec& spec) {
+  if (op == "build_node")             return op_build_node(spec);
+  if (op == "build_edges")            return op_build_edges(spec);
+  if (op == "add_pin")                return op_add_pin(spec);
+  if (op == "mutate")                 return op_mutate(spec);
+  if (op == "lookup")                 return op_lookup(spec);
+  // Single-graph traversals.
+  if (op == "traverse_forward_class") return op_traverse_forward_class(spec);
+  if (op == "traverse_fast_class")    return op_traverse_fast_class(spec);
+  // Hierarchy-flattening traversals (visit every node across all instances).
+  if (op == "traverse_forward_flat")  return op_traverse_forward_flat(spec);
+  if (op == "traverse_fast_flat")     return op_traverse_fast_flat(spec);
+  // Hierarchy-aware traversals (per-instance node visit).
+  if (op == "traverse_forward_hier")  return op_traverse_forward_hier(spec);
+  if (op == "traverse_fast_hier")     return op_traverse_fast_hier(spec);
+  // Instance-only walk (one yield per submodule, no inner-node visit).
+  if (op == "traverse_hier_range")    return op_traverse_hier_range(spec);
+  std::cerr << "hhds_bench: unknown op: " << op << "\n";
+  std::exit(3);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  const CliArgs a    = parse_args(argc, argv);
+  g_verify           = a.verify;
+  const auto    spec = spec_from(a);
+
+  if (a.emit_header) {
+    std::cout << "library,op,topology,axis,size,pins_per_node,hier_size,seed,run_idx,"
+              << "wall_ns,peak_rss_kb,bytes_per_node,l1_misses,llc_misses,instructions,cycles,ipc\n";
+  }
+
+  for (int run = 0; run < a.runs; ++run) {
+    const OpResult r = dispatch(a.op, spec);
+    std::cout << "hhds," << a.op << "," << a.topology << "," << a.axis << ","
+              << a.nodes << "," << a.pins << "," << a.hier << "," << a.seed << ","
+              << run << ","
+              << r.wall_ns
+              << ",0,0,0,0,0,0,0\n";  // wrapper rewrites these
+    if (g_verify) {
+      // Print to stderr so the CSV on stdout is unaffected. Run-by-run
+      // counts let you confirm flat/hier traversals actually descend
+      // into subnodes (visited >> top-graph-only would mean class).
+      std::fprintf(stderr,
+                   "verify: op=%s nodes=%d pins=%d hier=%d run=%d visited=%lld\n",
+                   a.op.c_str(), a.nodes, a.pins, a.hier, run,
+                   static_cast<long long>(r.visited));
+    }
+  }
+  return 0;
+}

--- a/hhds/bench/schema.md
+++ b/hhds/bench/schema.md
@@ -1,0 +1,73 @@
+# Bench CSV Schema
+
+Single source of truth for what every bench binary emits. `hhds_bench`,
+`boost_bench`, and the lgraph-side `lgraph_bench_thesis` all write rows
+matching this schema, so `scripts/merge_csv.py` can concatenate them
+without any per-binary special-casing.
+
+## Header (one line, written by every binary at startup)
+
+```
+library,op,topology,axis,size,pins_per_node,hier_size,seed,run_idx,wall_ns,peak_rss_kb,bytes_per_node,l1_misses,llc_misses,instructions,cycles,ipc
+```
+
+## Columns
+
+| Column | Type | Source | Notes |
+|---|---|---|---|
+| `library` | string | bench binary | One of `hhds`, `boost_directed`, `boost_bidirectional`, `lgraph`. |
+| `op` | string | `--op` | One of: `build_node`, `build_edges`, `add_pin`, `mutate`, `lookup`, or one of seven traversal variants — see "Traversal ops" below. |
+| `topology` | string | `--topology` | `chain`, `fanout`, `random_dag`, `eda_typical`. |
+| `axis` | string | `--axis` | Which sweep this row belongs to: `nodes`, `pins`, `hier`. Used by plot scripts to decide the x-axis. |
+| `size` | int | `--nodes` | Node count for this run. |
+| `pins_per_node` | int | `--pins` | Pins per node. 1 = pin-0-only. |
+| `hier_size` | int | `--hier` | Number of subgraph instances at depth-1; 1 = single-graph. |
+| `seed` | int | `--seed` | RNG seed used by the generator. Same seed → same topology across libraries. |
+| `run_idx` | int | bench loop | 0-indexed run within a (lib, op, params) tuple. |
+| `wall_ns` | int | google_benchmark | Median over all loop iterations of `benchmark::State::iterations()`. |
+| `peak_rss_kb` | int | wrapper | Filled by `scripts/run_all.sh` from `/usr/bin/time -v` — bench binary writes `0` here, wrapper rewrites the column. |
+| `bytes_per_node` | float | wrapper | `(rss_after − rss_before) / size`. Bench binary writes `0`; wrapper rewrites. |
+| `l1_misses` | int | wrapper | `perf stat -e L1-dcache-load-misses` (Linux only). Bench binary writes `0`; wrapper rewrites. macOS leaves as `0`. |
+| `llc_misses` | int | wrapper | `perf stat -e LLC-load-misses` (Linux only). Same handling. |
+| `instructions` | int | wrapper | `perf stat -e instructions` (Linux only). |
+| `cycles` | int | wrapper | `perf stat -e cycles` (Linux only). |
+| `ipc` | float | wrapper | `instructions / cycles`. macOS: `0`. |
+
+## Why the bench binary writes `0` for memory and perf columns
+
+Memory and cache counters can't be measured from inside the bench
+process without skewing the very numbers we want to measure. They're
+collected by wrapping the binary externally. The bench binary still
+**emits** those columns — with placeholder `0` — so the CSV header
+stays uniform and `scripts/run_all.sh` can rewrite them in place.
+
+## Traversal ops
+
+hhds exposes seven distinct traversal entry points
+([graph.hpp:507-519](../graph.hpp#L507-L519)). The bench measures each one
+as its own `op` so the comparison can isolate the cost of each axis
+(ordered vs unordered × class vs flat vs hier × instance-only).
+
+| op | hhds API called | What it visits | When to use |
+|---|---|---|---|
+| `traverse_forward_class` | `forward_class()` | All nodes of the top graph in topological order | Single-graph topo-sort cost |
+| `traverse_fast_class`    | `fast_class()`    | All nodes of the top graph, visit-once unordered | Single-graph fast pass cost |
+| `traverse_forward_flat`  | `forward_flat()`  | All nodes across all submodule instances, topo-ordered | Hier-flattening with order |
+| `traverse_fast_flat`     | `fast_flat()`     | All nodes across all instances, unordered | Hier-flattening fast |
+| `traverse_forward_hier`  | `forward_hier()`  | All nodes per-instance, topo-ordered, with hier context | Hier-aware ordered walk |
+| `traverse_fast_hier`     | `fast_hier()`     | All nodes per-instance, unordered | Hier-aware fast walk |
+| `traverse_hier_range`    | `hier_range()`    | One yield per submodule instance only (no inner nodes) | Module-tree / instance count |
+
+For Boost.Graph: only `traverse_forward_class` and `traverse_fast_class`
+have direct counterparts (BGL has no native hierarchy). The other five
+rows are reported as `N/A` for `library=boost_*` in the master CSV.
+
+For lgraph: all seven map to lgraph's `forward()` / `backward()` /
+`fast()` / hier-iterator equivalents. See `livehd/lgraph/lgraph.hpp`.
+
+## Determinism contract
+
+For a fixed `(library, op, topology, size, pins_per_node, hier_size, seed)`,
+the **edge list and traversal-visited-count must be identical across
+all libraries**. Verification step 6 in the plan asserts this. Mismatch
+= generator bug.

--- a/hhds/bench/scripts/plot.py
+++ b/hhds/bench/scripts/plot.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Plot a scaling chart from a master CSV produced by run_sweep.py.
+
+Output is a log-log line plot (one line per op, x = swept axis value,
+y = median wall_ns over all runs in that cell). Optionally splits by
+library when multiple libraries appear in the same CSV.
+
+Example:
+    python3 plot.py \\
+        --csv results/node_sweep.csv \\
+        --out results/node_sweep.png \\
+        --title "hhds: wall-time vs node count (chain topology)"
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")  # headless — no DISPLAY needed
+import matplotlib.pyplot as plt
+import pandas as pd
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--csv", required=True)
+    p.add_argument("--out", required=True)
+    p.add_argument("--title", default="")
+    p.add_argument("--y", default="wall_ns",
+                   help="Column to plot on y axis (wall_ns / peak_rss_kb / bytes_per_node).")
+    p.add_argument("--y-label", default="",
+                   help="Override y-axis label. Default derived from --y.")
+    return p.parse_args()
+
+
+Y_LABELS = {
+    "wall_ns": "wall-clock (ns, median)",
+    "peak_rss_kb": "peak RSS (kB)",
+    "bytes_per_node": "bytes per node",
+    "instructions": "instructions",
+    "cycles": "cycles",
+    "ipc": "instructions per cycle",
+}
+
+X_LABELS = {
+    "nodes": "node count",
+    "pins": "pins per node",
+    "hier": "submodule instances",
+}
+
+
+def main() -> int:
+    args = parse_args()
+
+    df = pd.read_csv(args.csv)
+    if df.empty:
+        sys.exit(f"{args.csv}: no rows")
+
+    axis = df["axis"].iloc[0]
+    if not (df["axis"] == axis).all():
+        sys.exit(f"CSV mixes axes ({df['axis'].unique()}) — can't plot one chart")
+
+    # The CSV's `size` column always means node count, but the axis being
+    # swept may be pins or hier. Pick the right column to plot on x.
+    axis_col = {"nodes": "size", "pins": "pins_per_node", "hier": "hier_size"}[axis]
+    df = df.rename(columns={axis_col: "_x"})
+
+    # Group by (library, topology, op, _x). Topology is included so that
+    # overflow-comparison runs (chain vs dense) plot as separate lines.
+    grp = df.groupby(["library", "topology", "op", "_x"])[args.y].median().reset_index()
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+
+    libs = sorted(grp["library"].unique())
+    topos = sorted(grp["topology"].unique())
+    ops = sorted(grp["op"].unique())
+
+    # Color palette: matplotlib default cycles 10 colors; for >10 ops we
+    # rely on tab20.
+    cmap = plt.get_cmap("tab20" if len(ops) > 10 else "tab10")
+    op_color = {op: cmap(i % cmap.N) for i, op in enumerate(ops)}
+
+    # Markers distinguish the OTHER axes (library and/or topology) so a
+    # single op's color appears as a family of related lines.
+    markers = ["o", "s", "^", "D", "v", "P", "X", "*"]
+    # Pair each (library, topology) combo with one marker.
+    lib_topo_marker = {}
+    for i, (lib, topo) in enumerate(sorted({(l, t) for l in libs for t in topos})):
+        lib_topo_marker[(lib, topo)] = markers[i % len(markers)]
+    # Dashed line style for "overflow-heavy" topologies so chain vs dense
+    # is visually obvious even in greyscale.
+    overflow_topos = {"dense"}
+
+    for lib in libs:
+        for topo in topos:
+            for op in ops:
+                sub = grp[(grp["library"] == lib) & (grp["topology"] == topo) & (grp["op"] == op)].sort_values("_x")
+                if sub.empty:
+                    continue
+                # Build label: drop redundant axes when only one value present.
+                parts = [op]
+                if len(libs) > 1:
+                    parts.insert(0, lib)
+                if len(topos) > 1:
+                    parts.append(f"({topo})")
+                label = " ".join(parts) if len(parts) > 1 else op
+                ax.plot(sub["_x"], sub[args.y],
+                        marker=lib_topo_marker[(lib, topo)],
+                        color=op_color[op],
+                        linewidth=1.5,
+                        markersize=6,
+                        linestyle="--" if topo in overflow_topos else "-",
+                        label=label)
+
+    ax.set_xscale("log")
+    ax.set_yscale("log")
+    ax.set_xlabel(X_LABELS.get(axis, axis))
+    ax.set_ylabel(args.y_label or Y_LABELS.get(args.y, args.y))
+    if args.title:
+        ax.set_title(args.title)
+    ax.grid(True, which="both", linestyle="--", alpha=0.4)
+    ax.legend(loc="best", fontsize=9, ncol=2 if len(ops) > 6 else 1)
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=144)
+    print(f"Wrote {out_path} ({len(grp)} (lib, op, size) groups)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hhds/bench/scripts/print_table.py
+++ b/hhds/bench/scripts/print_table.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Print a markdown-formatted comparison table from a master CSV.
+
+Pivot: rows = sweep value (size), columns = (library, op). One cell =
+median wall_ns formatted with SI suffix (ns / µs / ms / s). Useful to
+paste directly into the thesis chapter.
+
+Example:
+    python3 print_table.py --csv results/node_sweep.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import pandas as pd
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--csv", required=True)
+    p.add_argument("--metric", default="wall_ns",
+                   choices=["wall_ns", "peak_rss_kb", "bytes_per_node",
+                            "l1_misses", "llc_misses", "instructions", "cycles", "ipc"],
+                   help="Which CSV column to render (median per cell).")
+    return p.parse_args()
+
+
+def fmt_ns(v: float) -> str:
+    if pd.isna(v):
+        return "—"
+    if v < 1_000:
+        return f"{v:.0f} ns"
+    if v < 1_000_000:
+        return f"{v/1_000:.1f} µs"
+    if v < 1_000_000_000:
+        return f"{v/1_000_000:.2f} ms"
+    return f"{v/1_000_000_000:.2f} s"
+
+
+def fmt_int(v: float) -> str:
+    if pd.isna(v):
+        return "—"
+    return f"{int(v):,}"
+
+
+def fmt_float(v: float) -> str:
+    if pd.isna(v):
+        return "—"
+    return f"{v:.3f}"
+
+
+FORMATTERS = {
+    "wall_ns": fmt_ns,
+    "peak_rss_kb": fmt_int,
+    "bytes_per_node": fmt_float,
+    "l1_misses": fmt_int,
+    "llc_misses": fmt_int,
+    "instructions": fmt_int,
+    "cycles": fmt_int,
+    "ipc": fmt_float,
+}
+
+
+def main() -> int:
+    args = parse_args()
+    df = pd.read_csv(args.csv)
+    if df.empty:
+        sys.exit(f"{args.csv}: no rows")
+
+    axis = df["axis"].iloc[0]
+    fmt = FORMATTERS[args.metric]
+
+    # The CSV's `size` column is always node count. Pin/hier sweeps need
+    # to use their own axis column for the row index.
+    axis_col = {"nodes": "size", "pins": "pins_per_node", "hier": "hier_size"}[axis]
+
+    # Median per (library, topology, op, axis_value). Topology is in the
+    # group key so overflow-comparison runs (chain vs dense) become side-
+    # by-side columns instead of getting averaged together.
+    pivot = (df.groupby(["library", "topology", "op", axis_col])[args.metric]
+               .median()
+               .unstack(["library", "topology", "op"])
+               .sort_index())
+
+    # Format header. Drop axes that only have one unique value so the
+    # column names stay readable.
+    cols = pivot.columns.tolist()  # list of (library, topology, op) tuples
+    one_lib = all(lib == cols[0][0] for lib, _, _ in cols)
+    one_topo = all(topo == cols[0][1] for _, topo, _ in cols)
+    def col_name(lib: str, topo: str, op: str) -> str:
+        parts: list[str] = []
+        if not one_lib:
+            parts.append(lib)
+        parts.append(op)
+        if not one_topo:
+            parts.append(f"({topo})")
+        return " ".join(parts)
+    header = ["size"] + [col_name(lib, topo, op) for lib, topo, op in cols]
+
+    # Header label tracks which axis was actually swept.
+    axis_header = {"nodes": "nodes", "pins": "pins/node", "hier": "instances"}[axis]
+    header[0] = axis_header
+
+    print(f"# {axis} sweep — {args.metric} (median across runs)\n")
+    print("| " + " | ".join(header) + " |")
+    print("|" + "|".join(["---"] * len(header)) + "|")
+    for value, row in pivot.iterrows():
+        cells = [f"{int(value):,}"] + [fmt(row[col]) for col in cols]
+        print("| " + " | ".join(cells) + " |")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hhds/bench/scripts/run_hier_sweep.sh
+++ b/hhds/bench/scripts/run_hier_sweep.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Sweep submodule-instance count from 1 -> 1000 at a fixed inner-graph
+# size (1000 nodes per sub). This is the hierarchy-scaling axis: tests
+# how flat / hier / hier_range traversal cost grows as the same class
+# graph is instantiated more times.
+#
+# Usage:
+#   bash run_hier_sweep.sh [output-dir]
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."  # run from bench/ dir
+
+OUT_DIR="${1:-results/$(date +%Y-%m-%d)}"
+mkdir -p "$OUT_DIR"
+
+BENCH="../../bazel-bin/hhds/bench/hhds_bench"
+
+if [[ ! -x "$BENCH" ]]; then
+  echo "bench binary missing — run: bazel build //hhds/bench:hhds_bench" >&2
+  exit 1
+fi
+
+# All five hier-aware traversals plus hier_range.
+OPS="traverse_fast_flat,traverse_forward_flat,traverse_fast_hier,traverse_forward_hier,traverse_hier_range"
+
+# 1, 10, 100, 1000 — keeps total node count reasonable. With N_inner=1000:
+#   hier=1   -> 1K nodes total
+#   hier=1K  -> 1M nodes total
+SIZES="1,10,100,1000"
+
+.venv/bin/python scripts/run_sweep.py \
+  --sweep hier \
+  --bench "$BENCH" \
+  --ops "$OPS" \
+  --sizes "$SIZES" \
+  --out "$OUT_DIR/hier_sweep.csv" \
+  --runs 5 \
+  --fixed-nodes 1000
+
+echo ""
+echo "Done. Next:"
+echo "  .venv/bin/python scripts/plot.py --csv $OUT_DIR/hier_sweep.csv --out $OUT_DIR/hier_sweep.png --title 'hhds: hier traversals vs instance count (N_inner=1000)'"
+echo "  .venv/bin/python scripts/print_table.py --csv $OUT_DIR/hier_sweep.csv"

--- a/hhds/bench/scripts/run_inline_vs_overflow.sh
+++ b/hhds/bench/scripts/run_inline_vs_overflow.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Compare hhds performance with edges in pure inline storage vs pure overflow.
+#
+#   sedges_only   topology -> 2 edges/node forward
+#                              middle nodes have ~4 total edges
+#                              all stored in 4-slot sedges_ packed path (fastest)
+#                              never enters ledge0/ledge1 / sedges_extra / overflow
+#
+#   overflow_only topology -> 16 edges/node forward
+#                              middle nodes have ~32 total edges
+#                              well past 10-edge node-overflow threshold
+#                              hhds flushes inline content into overflow set;
+#                              all edges live in the overflow set with no
+#                              inline content remaining.
+#
+# Both topologies are run across the same node sweep (10 -> 10^6) and
+# emitted into one CSV. plot.py / print_table.py distinguish lines by
+# the `topology` column.
+#
+# Usage:
+#   bash run_inline_vs_overflow.sh [output-dir]
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."  # run from bench/ dir
+
+OUT_DIR="${1:-results/$(date +%Y-%m-%d)}"
+mkdir -p "$OUT_DIR"
+
+BENCH="../../bazel-bin/hhds/bench/hhds_bench"
+
+if [[ ! -x "$BENCH" ]]; then
+  echo "bench binary missing — run: bazel build //hhds/bench:hhds_bench" >&2
+  exit 1
+fi
+
+OPS="build_node,build_edges,traverse_fast_class,traverse_forward_class,lookup"
+SIZES="10,100,1000,10000,100000,1000000"
+CSV="$OUT_DIR/inline_vs_overflow.csv"
+
+# Sedges-only first -> creates CSV with header + sedges rows.
+.venv/bin/python scripts/run_sweep.py \
+  --sweep nodes \
+  --bench "$BENCH" \
+  --ops "$OPS" \
+  --sizes "$SIZES" \
+  --out "$CSV" \
+  --runs 5 \
+  --topology sedges_only \
+  --timeout-per-cell 240
+
+# Overflow-only second -> append to same CSV (skip header).
+TMP="$OUT_DIR/_inline_vs_overflow_tmp.csv"
+.venv/bin/python scripts/run_sweep.py \
+  --sweep nodes \
+  --bench "$BENCH" \
+  --ops "$OPS" \
+  --sizes "$SIZES" \
+  --out "$TMP" \
+  --runs 5 \
+  --topology overflow_only \
+  --timeout-per-cell 240
+
+tail -n +2 "$TMP" >> "$CSV"
+rm -f "$TMP"
+
+echo ""
+echo "Combined CSV: $CSV"
+echo ""
+echo "Done. Next:"
+echo "  .venv/bin/python scripts/plot.py --csv $CSV --out $OUT_DIR/inline_vs_overflow.png --title 'hhds: sedges_only (≤4 edges/node) vs overflow_only (16 edges/node)'"
+echo "  .venv/bin/python scripts/print_table.py --csv $CSV"

--- a/hhds/bench/scripts/run_node_sweep.sh
+++ b/hhds/bench/scripts/run_node_sweep.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Sweep node count from 10 -> 1,000,000 across the core ops.
+# Topology fixed at 'chain' (predictable, linear traversal cost).
+# Pins fixed at 1 (pin-0 fast path — best case for hhds).
+#
+# Usage:
+#   bash run_node_sweep.sh [output-dir]
+#
+# Output:
+#   <output-dir>/node_sweep.csv  — master CSV
+#
+# After this finishes, plot.py and print_table.py consume node_sweep.csv.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."  # run from bench/ dir
+
+OUT_DIR="${1:-results/$(date +%Y-%m-%d)}"
+mkdir -p "$OUT_DIR"
+
+BENCH="../../bazel-bin/hhds/bench/hhds_bench"
+
+if [[ ! -x "$BENCH" ]]; then
+  echo "bench binary missing — run: bazel build //hhds/bench:hhds_bench" >&2
+  exit 1
+fi
+
+# Five core ops covering creation, edge insertion, traversal (both
+# variants), and lookup. add_pin / mutate / hier ops have their own
+# sweeps in run_pin_sweep.sh / run_hier_sweep.sh.
+OPS="build_node,build_edges,traverse_fast_class,traverse_forward_class,lookup"
+
+# 10, 100, 1K, 10K, 100K, 1M — six points, clean log-log.
+SIZES="10,100,1000,10000,100000,1000000"
+
+.venv/bin/python scripts/run_sweep.py \
+  --sweep nodes \
+  --bench "$BENCH" \
+  --ops "$OPS" \
+  --sizes "$SIZES" \
+  --out "$OUT_DIR/node_sweep.csv" \
+  --runs 5 \
+  --topology chain
+
+echo ""
+echo "Done. Next:"
+echo "  .venv/bin/python scripts/plot.py --csv $OUT_DIR/node_sweep.csv --out $OUT_DIR/node_sweep.png --title 'hhds: wall-time vs node count (chain)'"
+echo "  .venv/bin/python scripts/print_table.py --csv $OUT_DIR/node_sweep.csv"

--- a/hhds/bench/scripts/run_overflow_compare.sh
+++ b/hhds/bench/scripts/run_overflow_compare.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Compare hhds performance with vs without edge-storage overflow.
+#
+#   chain  topology -> 1 edge per node    -> stays in inline storage  (no overflow)
+#   dense  topology -> 32 edges per node  -> always spills to overflow scanning array
+#
+# (hhds's MAX_EDGES = 8 inline slots per node/pin, so 32 forces overflow on every node.)
+#
+# Both topologies are run across the same node sweep (10 -> 10^6) and
+# emitted into a single CSV. plot.py and print_table.py distinguish
+# rows by the `topology` column, so the chart shows two lines per op
+# (solid = chain, dashed = dense).
+#
+# Usage:
+#   bash run_overflow_compare.sh [output-dir]
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."  # run from bench/ dir
+
+OUT_DIR="${1:-results/$(date +%Y-%m-%d)}"
+mkdir -p "$OUT_DIR"
+
+BENCH="../../bazel-bin/hhds/bench/hhds_bench"
+
+if [[ ! -x "$BENCH" ]]; then
+  echo "bench binary missing — run: bazel build //hhds/bench:hhds_bench" >&2
+  exit 1
+fi
+
+OPS="build_node,build_edges,traverse_fast_class,traverse_forward_class,lookup"
+SIZES="10,100,1000,10000,100000,1000000"
+CSV="$OUT_DIR/overflow_compare.csv"
+
+# Run chain first -> writes header + chain rows.
+.venv/bin/python scripts/run_sweep.py \
+  --sweep nodes \
+  --bench "$BENCH" \
+  --ops "$OPS" \
+  --sizes "$SIZES" \
+  --out "$CSV" \
+  --runs 5 \
+  --topology chain \
+  --timeout-per-cell 180
+
+# Run dense second -> appends rows to same CSV. The header is already
+# present, and the bench binary uses --no-header from run_sweep.py.
+# But run_sweep.py's --out creates a new file, so we need a small trick:
+# write dense to a temp CSV, then append dense's data rows (skipping the
+# header) to the master.
+DENSE_CSV="$OUT_DIR/_overflow_dense_tmp.csv"
+.venv/bin/python scripts/run_sweep.py \
+  --sweep nodes \
+  --bench "$BENCH" \
+  --ops "$OPS" \
+  --sizes "$SIZES" \
+  --out "$DENSE_CSV" \
+  --runs 5 \
+  --topology dense \
+  --timeout-per-cell 180
+
+# Append all but the header line from the dense CSV to the chain CSV.
+tail -n +2 "$DENSE_CSV" >> "$CSV"
+rm -f "$DENSE_CSV"
+
+echo ""
+echo "Combined CSV: $CSV"
+echo ""
+echo "Done. Next:"
+echo "  .venv/bin/python scripts/plot.py --csv $CSV --out $OUT_DIR/overflow_compare.png --title 'hhds: chain (no overflow) vs dense (always overflow)'"
+echo "  .venv/bin/python scripts/print_table.py --csv $CSV"

--- a/hhds/bench/scripts/run_pin_sweep.sh
+++ b/hhds/bench/scripts/run_pin_sweep.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Sweep pins-per-node across 1, 2, 4, 8, 16, 64, 256 at fixed N=1000.
+# Values chosen to cross hhds's three storage regimes:
+#   1            -> pin-0 fast path (no pin entry)
+#   2..16        -> inline edges in Pin_class
+#   64           -> overflow scanning array
+#   256          -> emhash8 hashset escape hatch
+# This is the headline thesis figure for the inline -> overflow ->
+# hashset transition.
+#
+# Usage:
+#   bash run_pin_sweep.sh [output-dir]
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."  # run from bench/ dir
+
+OUT_DIR="${1:-results/$(date +%Y-%m-%d)}"
+mkdir -p "$OUT_DIR"
+
+BENCH="../../bazel-bin/hhds/bench/hhds_bench"
+
+if [[ ! -x "$BENCH" ]]; then
+  echo "bench binary missing — run: bazel build //hhds/bench:hhds_bench" >&2
+  exit 1
+fi
+
+OPS="add_pin"
+SIZES="1,2,4,8,16,64,256"
+
+.venv/bin/python scripts/run_sweep.py \
+  --sweep pins \
+  --bench "$BENCH" \
+  --ops "$OPS" \
+  --sizes "$SIZES" \
+  --out "$OUT_DIR/pin_sweep.csv" \
+  --runs 5 \
+  --fixed-nodes 1000
+
+echo ""
+echo "Done. Next:"
+echo "  .venv/bin/python scripts/plot.py --csv $OUT_DIR/pin_sweep.csv --out $OUT_DIR/pin_sweep.png --title 'hhds add_pin: storage-regime crossover (N=1000)'"
+echo "  .venv/bin/python scripts/print_table.py --csv $OUT_DIR/pin_sweep.csv"

--- a/hhds/bench/scripts/run_sweep.py
+++ b/hhds/bench/scripts/run_sweep.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Sweep runner for hhds_bench / boost_bench / lgraph_bench_thesis.
+
+Calls the bench binary repeatedly with varying parameters and writes one
+master CSV that downstream plot.py / print_table.py consume.
+
+Example:
+    python3 run_sweep.py \\
+        --sweep nodes \\
+        --bench bazel-bin/hhds/bench/hhds_bench \\
+        --ops build_node,build_edges,traverse_fast_class,traverse_forward_class,lookup \\
+        --sizes 10,100,1000,10000,100000,1000000 \\
+        --out results/node_sweep.csv \\
+        --runs 5
+
+The CSV uses the schema documented in bench/schema.md. The bench binary
+emits the header on its first invocation; subsequent invocations append
+with --no-header so the output is a single concatenable file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+VALID_SWEEPS = ("nodes", "pins", "hier")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--sweep", required=True, choices=VALID_SWEEPS,
+                   help="Which axis to sweep.")
+    p.add_argument("--bench", required=True,
+                   help="Path to bench binary (e.g. bazel-bin/hhds/bench/hhds_bench).")
+    p.add_argument("--ops", required=True,
+                   help="Comma-separated op names (see schema.md).")
+    p.add_argument("--sizes", required=True,
+                   help="Comma-separated sweep values (e.g. '10,100,1000').")
+    p.add_argument("--out", required=True,
+                   help="Output CSV path. Parent dir is created if needed.")
+    p.add_argument("--runs", type=int, default=5,
+                   help="Number of runs per (op, size) cell. Median is what plot.py uses.")
+    p.add_argument("--topology", default="chain",
+                   help="Synthetic topology (chain/fanout/random_dag/eda_typical).")
+    p.add_argument("--seed", default="0xC0FFEE",
+                   help="RNG seed for the generator. Same seed = same edges across libs.")
+    # Held-constant values for axes NOT being swept. Safe defaults match
+    # the plan's workload constants.
+    p.add_argument("--fixed-nodes", type=int, default=100_000,
+                   help="Node count when --sweep != nodes.")
+    p.add_argument("--fixed-pins", type=int, default=1,
+                   help="Pins/node when --sweep != pins.")
+    p.add_argument("--fixed-hier", type=int, default=1,
+                   help="Hier instance count when --sweep != hier.")
+    p.add_argument("--timeout-per-cell", type=float, default=120.0,
+                   help="Per-(op,size) wall budget in seconds. Cells exceeding this skip.")
+    return p.parse_args()
+
+
+def cell_args(args: argparse.Namespace, op: str, value: int) -> list[str]:
+    """Build CLI args for one (op, swept-value) cell."""
+    nodes = args.fixed_nodes
+    pins  = args.fixed_pins
+    hier  = args.fixed_hier
+    if args.sweep == "nodes":
+        nodes = value
+    elif args.sweep == "pins":
+        pins = value
+    elif args.sweep == "hier":
+        hier = value
+
+    return [
+        args.bench,
+        f"--op={op}",
+        f"--topology={args.topology}",
+        f"--axis={args.sweep}",
+        f"--nodes={nodes}",
+        f"--pins={pins}",
+        f"--hier={hier}",
+        f"--seed={args.seed}",
+        f"--runs={args.runs}",
+        "--no-header",
+    ]
+
+
+def main() -> int:
+    args = parse_args()
+    ops = [op.strip() for op in args.ops.split(",") if op.strip()]
+    sizes = [int(s.strip()) for s in args.sizes.split(",") if s.strip()]
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not Path(args.bench).is_file():
+        sys.exit(f"bench binary not found: {args.bench}")
+
+    # Header line — the bench binaries don't write it when --no-header is
+    # passed, so the driver writes it once up front.
+    header = ("library,op,topology,axis,size,pins_per_node,hier_size,seed,run_idx,"
+              "wall_ns,peak_rss_kb,bytes_per_node,l1_misses,llc_misses,instructions,cycles,ipc\n")
+
+    n_cells = len(ops) * len(sizes)
+    cell = 0
+    t_start = time.time()
+    skipped: list[tuple[str, int]] = []
+
+    with out_path.open("w") as fout:
+        fout.write(header)
+        fout.flush()
+
+        for op in ops:
+            for size in sizes:
+                cell += 1
+                argv = cell_args(args, op, size)
+                desc = f"[{cell}/{n_cells}] {op} {args.sweep}={size}"
+                print(desc, file=sys.stderr, flush=True)
+                t0 = time.time()
+                try:
+                    proc = subprocess.run(
+                        argv,
+                        capture_output=True,
+                        text=True,
+                        timeout=args.timeout_per_cell,
+                    )
+                except subprocess.TimeoutExpired:
+                    elapsed = time.time() - t0
+                    print(f"  TIMEOUT after {elapsed:.1f}s — skipping", file=sys.stderr)
+                    skipped.append((op, size))
+                    continue
+                elapsed = time.time() - t0
+
+                if proc.returncode != 0:
+                    print(f"  rc={proc.returncode} stderr={proc.stderr.strip()[:200]}",
+                          file=sys.stderr)
+                    skipped.append((op, size))
+                    continue
+
+                fout.write(proc.stdout)
+                fout.flush()
+                # Quick wall-time signal so the user can spot regressions live.
+                lines = [l for l in proc.stdout.strip().split("\n") if l]
+                if lines:
+                    last_ns = lines[-1].split(",")[9]  # wall_ns column
+                    print(f"  ok ({elapsed:.2f}s, last wall_ns={last_ns})",
+                          file=sys.stderr)
+
+    total = time.time() - t_start
+    print(f"\nWrote {out_path} in {total:.1f}s "
+          f"({n_cells - len(skipped)}/{n_cells} cells)",
+          file=sys.stderr)
+    if skipped:
+        print(f"Skipped: {skipped}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hhds/graph.cpp
+++ b/hhds/graph.cpp
@@ -703,6 +703,9 @@ void Graph::invalidate_from_library() noexcept {
   forward_pass2_cache_.clear();
   forward_remaining_in_cache_.clear();
   forward_caches_valid_ = false;
+  backward_pass2_cache_.clear();
+  backward_remaining_out_cache_.clear();
+  backward_caches_valid_ = false;
   if (tree_) {
     tree_->clear();
   }
@@ -801,6 +804,7 @@ void Graph::bind_library(const GraphLibrary* owner, Gid self_gid) noexcept {
 void Graph::invalidate_traversal_caches() noexcept {
   dirty_                = true;
   forward_caches_valid_ = false;
+  backward_caches_valid_ = false;
   if (owner_lib_ != nullptr) {
     owner_lib_->note_graph_mutation();
   }
@@ -945,6 +949,136 @@ void Graph::ensure_forward_caches() const {
   // Tail (cycle survivors) is not cached — the streaming iterator re-derives
   // it by scanning for alive-but-unemitted entries after Pass 2 completes.
   forward_caches_valid_ = true;
+}
+
+bool Graph::backward_is_sink(size_t idx) const noexcept {
+  if (idx == 2) {
+    return true;
+  }
+  if (idx < kForwardFirstIdx) {
+    return false;
+  }
+  if (idx >= node_table.size()) {
+    return false;
+  }
+  return node_table[idx].is_loop_last();
+}
+
+void Graph::ensure_backward_caches() const {
+  if (backward_caches_valid_) {
+    return;
+  }
+  const size_t node_count = node_table.size();
+
+  backward_pass2_cache_.clear();
+  backward_remaining_out_cache_.assign(node_count, 0);
+
+  if (node_count <= kForwardFirstIdx) {
+    backward_caches_valid_ = true;
+    return;
+  }
+
+  // Resolve a driver Vid back to its owning node index.
+  auto driver_idx_of = [&](Vid vid) -> size_t {
+    Nid driver_nid;
+    if (vid & static_cast<Vid>(1)) {
+      const Pid driver_pid = (static_cast<Pid>(vid) & ~static_cast<Pid>(2)) | static_cast<Pid>(1);
+      driver_nid           = ref_pin(driver_pid)->get_master_nid();
+    } else {
+      driver_nid = static_cast<Nid>(vid);
+    }
+    driver_nid = driver_nid & ~static_cast<Nid>(3);
+    return static_cast<size_t>(driver_nid >> 2);
+  };
+
+  // Enumerate every upstream driver idx reachable from sink_idx
+  auto for_each_in_driver = [&](size_t sink_idx, auto&& f) {
+    const Nid sink_nid = static_cast<Nid>(sink_idx) << 2;
+    auto      node_edges = node_table[sink_idx].get_edges(sink_nid, overflow_sets_);
+    for (auto vid : node_edges) {
+      if (!(vid & static_cast<Vid>(2))) {
+        continue;
+      }
+      const size_t driver_idx = driver_idx_of(vid);
+      if (driver_idx >= kForwardFirstIdx && driver_idx < node_count) {
+        f(driver_idx);
+      }
+    }
+    for (Pid pin_vid = node_table[sink_idx].get_next_pin_id(); pin_vid != 0;) {
+      const Pid canonical_pin = (pin_vid & ~static_cast<Pid>(2)) | static_cast<Pid>(1);
+      auto      pin_edges     = ref_pin(canonical_pin)->get_edges(canonical_pin, overflow_sets_);
+      for (auto edge_vid : pin_edges) {
+        if (!(edge_vid & static_cast<Vid>(2))) {
+          continue;
+        }
+        const size_t driver_idx = driver_idx_of(edge_vid);
+        if (driver_idx >= kForwardFirstIdx && driver_idx < node_count) {
+          f(driver_idx);
+        }
+      }
+      pin_vid = ref_pin(canonical_pin)->get_next_pin_id();
+    }
+  };
+
+  // Pre-pass: initial out-edge counts.
+  auto& remaining_out = backward_remaining_out_cache_;
+  for (size_t sink_idx = kForwardFirstIdx; sink_idx < node_count; ++sink_idx) {
+    if (!node_table[sink_idx].is_alive() || backward_is_sink(sink_idx)) {
+      continue;
+    }
+    for_each_in_driver(sink_idx, [&](size_t driver_idx) {
+      if (!backward_is_sink(driver_idx)) {
+        ++remaining_out[driver_idx];
+      }
+    });
+  }
+
+  // Full Pass 1 + Pass 2 dry run to populate backward_pass2_cache_. Uses a
+  // working copy so `remaining_out` (the cache) keeps its initial values.
+  std::vector<uint32_t> working = remaining_out;
+  std::vector<uint64_t> emitted_bits((node_count + 63) / 64, 0);
+  auto                  mark_emit = [&](size_t idx) { emitted_bits[idx >> 6] |= (1ULL << (idx & 63)); };
+  auto                  is_emit   = [&](size_t idx) { return (emitted_bits[idx >> 6] >> (idx & 63)) & 1ULL; };
+
+  auto propagate = [&](size_t sink_idx, size_t cursor) {
+    if (backward_is_sink(sink_idx)) {
+      return;
+    }
+    for_each_in_driver(sink_idx, [&](size_t driver_idx) {
+      if (is_emit(driver_idx) || backward_is_sink(driver_idx)) {
+        return;
+      }
+      if (working[driver_idx] == 0) {
+        return;
+      }
+      --working[driver_idx];
+      if (working[driver_idx] == 0 && driver_idx >= cursor) {
+        backward_pass2_cache_.push_back(static_cast<Nid>(driver_idx) << 2);
+      }
+    });
+  };
+
+  for (size_t idx = node_count; idx > kForwardFirstIdx;) {
+    --idx;
+    if (!node_table[idx].is_alive() || is_emit(idx)) {
+      continue;
+    }
+    if (backward_is_sink(idx) || working[idx] == 0) {
+      mark_emit(idx);
+      propagate(idx, idx);
+    }
+  }
+
+  for (size_t head = 0; head < backward_pass2_cache_.size(); ++head) {
+    const size_t idx = static_cast<size_t>(backward_pass2_cache_[head] >> 2);
+    if (is_emit(idx)) {
+      continue;
+    }
+    mark_emit(idx);
+    propagate(idx, 0); // Propagate backwards with cursor=0 so all deferrals are added
+  }
+
+  backward_caches_valid_ = true;
 }
 
 auto Graph::create_node() -> Node {
@@ -1433,6 +1567,7 @@ void Node_class::set_subnode(const std::shared_ptr<GraphIO>& graphio) const {
 void Node_class::set_type(Type type) const {
   assert(graph_ != nullptr && "set_type: node is not attached to a graph");
   graph_->ref_node(raw_nid)->set_type(type);
+  graph_->invalidate_traversal_caches();
 }
 
 Type Node_class::get_type() const {
@@ -1673,6 +1808,11 @@ ForwardClassRange Graph::forward_class() const noexcept {
   return ForwardClassRange(const_cast<Graph*>(this));
 }
 
+BackwardClassRange Graph::backward_class() const noexcept {
+  assert_accessible();
+  return BackwardClassRange(const_cast<Graph*>(this));
+}
+
 FastFlatRange Graph::fast_flat() const noexcept { return FastFlatRange(const_cast<Graph*>(this)); }
 
 FastHierRange Graph::fast_hier() const noexcept { return FastHierRange(const_cast<Graph*>(this)); }
@@ -1849,6 +1989,16 @@ ForwardFlatRange Graph::forward_flat() const noexcept {
 ForwardHierRange Graph::forward_hier() const noexcept {
   assert_accessible();
   return ForwardHierRange(const_cast<Graph*>(this));
+}
+
+BackwardFlatRange Graph::backward_flat() const noexcept {
+  assert_accessible();
+  return BackwardFlatRange(const_cast<Graph*>(this));
+}
+
+BackwardHierRange Graph::backward_hier() const noexcept {
+  assert_accessible();
+  return BackwardHierRange(const_cast<Graph*>(this));
 }
 
 // --- ForwardClassIterator ---
@@ -2133,6 +2283,280 @@ ForwardHierIterator& ForwardHierIterator::operator++() {
 }
 
 ForwardHierIterator ForwardHierRange::begin() const { return ForwardHierIterator(graph_); }
+
+// --- BackwardClassIterator ---
+//
+// Replays the reverse topological emission order using backward_pass2_cache_ and
+// initial out-edge counts.
+
+BackwardClassIterator::BackwardClassIterator(Graph* graph) : graph_(graph) {
+  if (graph_ == nullptr) {
+    phase_ = Phase::End;
+    return;
+  }
+  graph_->ensure_backward_caches();
+  node_count_ = graph_->node_table.size();
+  if (node_count_ <= kForwardFirstIdx) {
+    phase_ = Phase::End;
+    return;
+  }
+  working_remaining_out_ = graph_->backward_remaining_out_cache_;
+  emitted_bits_.assign((node_count_ + 63) / 64, 0);
+  phase_ = Phase::Pass1;
+  idx_   = node_count_;
+  advance();
+}
+
+BackwardClassIterator::BackwardClassIterator(BackwardClassIterator&& o) noexcept = default;
+BackwardClassIterator& BackwardClassIterator::operator=(BackwardClassIterator&& o) noexcept = default;
+
+bool BackwardClassIterator::is_sink(size_t idx) const noexcept { return graph_->backward_is_sink(idx); }
+
+bool BackwardClassIterator::is_emitted(size_t idx) const noexcept {
+  return (emitted_bits_[idx >> 6] >> (idx & 63)) & 1ULL;
+}
+
+void BackwardClassIterator::mark_emitted(size_t idx) noexcept { emitted_bits_[idx >> 6] |= (1ULL << (idx & 63)); }
+
+void BackwardClassIterator::propagate(size_t sink_idx, size_t /*cursor*/) {
+  if (is_sink(sink_idx)) {
+    return;
+  }
+
+  auto driver_idx_of = [&](Vid vid) -> size_t {
+    Nid driver_nid;
+    if (vid & static_cast<Vid>(1)) {
+      const Pid driver_pid = (static_cast<Pid>(vid) & ~static_cast<Pid>(2)) | static_cast<Pid>(1);
+      driver_nid           = graph_->ref_pin(driver_pid)->get_master_nid();
+    } else {
+      driver_nid = static_cast<Nid>(vid);
+    }
+    driver_nid = driver_nid & ~static_cast<Nid>(3);
+    return static_cast<size_t>(driver_nid >> 2);
+  };
+
+  auto try_dec = [&](size_t driver_idx) {
+    if (driver_idx < kForwardFirstIdx || driver_idx >= node_count_) {
+      return;
+    }
+    if (is_emitted(driver_idx) || is_sink(driver_idx)) {
+      return;
+    }
+    if (working_remaining_out_[driver_idx] == 0) {
+      return;
+    }
+    --working_remaining_out_[driver_idx];
+  };
+
+  const Nid sink_nid = static_cast<Nid>(sink_idx) << 2;
+  auto      node_edges = graph_->node_table[sink_idx].get_edges(sink_nid, graph_->overflow_sets_);
+  for (auto vid : node_edges) {
+    if (!(vid & static_cast<Vid>(2))) {
+      continue;
+    }
+    try_dec(driver_idx_of(vid));
+  }
+  for (Pid pin_vid = graph_->node_table[sink_idx].get_next_pin_id(); pin_vid != 0;) {
+    const Pid canonical_pin = (pin_vid & ~static_cast<Pid>(2)) | static_cast<Pid>(1);
+    auto      pin_edges     = graph_->ref_pin(canonical_pin)->get_edges(canonical_pin, graph_->overflow_sets_);
+    for (auto edge_vid : pin_edges) {
+      if (!(edge_vid & static_cast<Vid>(2))) {
+        continue;
+      }
+      try_dec(driver_idx_of(edge_vid));
+    }
+    pin_vid = graph_->ref_pin(canonical_pin)->get_next_pin_id();
+  }
+}
+
+void BackwardClassIterator::advance() {
+  while (true) {
+    if (phase_ == Phase::Pass1) {
+      while (idx_ > kForwardFirstIdx) {
+        const size_t i = --idx_;
+        if (!graph_->node_table[i].is_alive() || is_emitted(i)) {
+          continue;
+        }
+        if (is_sink(i) || working_remaining_out_[i] == 0) {
+          mark_emitted(i);
+          propagate(i, i);
+          current_idx_ = i;
+          return;
+        }
+      }
+      phase_      = Phase::Pass2;
+      pass2_head_ = 0;
+      continue;
+    }
+    if (phase_ == Phase::Pass2) {
+      const auto& cache = graph_->backward_pass2_cache_;
+      while (pass2_head_ < cache.size()) {
+        const size_t i = static_cast<size_t>(cache[pass2_head_++] >> 2);
+        if (i >= node_count_ || is_emitted(i) || !graph_->node_table[i].is_alive()) {
+          continue;
+        }
+        mark_emitted(i);
+        current_idx_ = i;
+        return;
+      }
+      phase_ = Phase::Tail;
+      idx_   = node_count_;
+      continue;
+    }
+    if (phase_ == Phase::Tail) {
+      while (idx_ > kForwardFirstIdx) {
+        const size_t i = --idx_;
+        if (!graph_->node_table[i].is_alive() || is_emitted(i)) {
+          continue;
+        }
+        mark_emitted(i);
+        current_idx_ = i;
+        return;
+      }
+      phase_       = Phase::End;
+      current_idx_ = 0;
+      return;
+    }
+    return;  // End
+  }
+}
+
+Node_class BackwardClassIterator::operator*() const {
+  return Node_class(graph_, static_cast<Nid>(current_idx_) << 2);
+}
+
+BackwardClassIterator& BackwardClassIterator::operator++() {
+  advance();
+  return *this;
+}
+
+BackwardClassIterator BackwardClassRange::begin() const { return BackwardClassIterator(graph_); }
+
+size_t BackwardClassRange::size() const {
+  size_t n = 0;
+  for (auto it = begin(); it != end(); ++it) {
+    ++n;
+  }
+  return n;
+}
+
+Node_class BackwardClassRange::front() const {
+  auto it = begin();
+  assert(it != end() && "BackwardClassRange::front() on empty range");
+  return *it;
+}
+
+bool BackwardClassRange::empty() const { return begin() == end(); }
+
+// --- BackwardFlatIterator ---
+
+BackwardFlatIterator::BackwardFlatIterator(Graph* root_graph) {
+  if (root_graph == nullptr) {
+    return;
+  }
+  root_graph->assert_accessible();
+  top_graph_ = root_graph->self_gid_;
+  if (top_graph_ != Gid_invalid) {
+    active_graphs_.insert(top_graph_);
+  }
+  stack_.push_back(Frame{root_graph, BackwardClassIterator(root_graph)});
+  advance();
+}
+
+void BackwardFlatIterator::advance() {
+  while (!stack_.empty()) {
+    auto& frame = stack_.back();
+    if (frame.it == BackwardClassIterator{}) {
+      stack_.pop_back();
+      continue;
+    }
+    return;  // positioned
+  }
+}
+
+Node_class BackwardFlatIterator::operator*() const {
+  const auto& frame   = stack_.back();
+  const Nid   raw_nid = (*frame.it).get_debug_nid();
+  return Node_class(frame.graph, top_graph_, raw_nid);
+}
+
+BackwardFlatIterator& BackwardFlatIterator::operator++() {
+  auto&       frame      = stack_.back();
+  const Nid   cur_nid    = (*frame.it).get_debug_nid();
+  const auto& entry      = frame.graph->node_table[static_cast<size_t>(cur_nid >> 2)];
+  const auto* lib        = frame.graph->owner_lib_;
+  ++frame.it;
+  if (entry.has_subnode() && lib != nullptr) {
+    const Gid sub = entry.get_subnode();
+    if (lib->has_graph(sub) && active_graphs_.find(sub) == active_graphs_.end()) {
+      Graph* child = const_cast<Graph*>(lib->get_graph(sub).get());
+      active_graphs_.insert(sub);
+      stack_.push_back(Frame{child, BackwardClassIterator(child)});
+    }
+  }
+  advance();
+  return *this;
+}
+
+BackwardFlatIterator BackwardFlatRange::begin() const { return BackwardFlatIterator(graph_); }
+
+// --- BackwardHierIterator ---
+
+BackwardHierIterator::BackwardHierIterator(Graph* root_graph) {
+  if (root_graph == nullptr) {
+    return;
+  }
+  root_graph->assert_accessible();
+  root_gid_ = root_graph->self_gid_;
+  if (root_gid_ != Gid_invalid) {
+    active_graphs_.insert(root_gid_);
+  }
+  stack_.push_back(Frame{root_graph, BackwardClassIterator(root_graph), static_cast<Tree_pos>(ROOT)});
+  advance();
+}
+
+void BackwardHierIterator::advance() {
+  while (!stack_.empty()) {
+    auto& frame = stack_.back();
+    if (frame.it == BackwardClassIterator{}) {
+      const Gid popped = frame.graph->self_gid_;
+      stack_.pop_back();
+      if (popped != Gid_invalid) {
+        active_graphs_.erase(popped);
+      }
+      continue;
+    }
+    return;
+  }
+}
+
+Node_class BackwardHierIterator::operator*() const {
+  const auto& frame   = stack_.back();
+  const Nid   raw_nid = (*frame.it).get_debug_nid();
+  return Node_class(frame.graph, root_gid_, frame.hier_pos, raw_nid);
+}
+
+BackwardHierIterator& BackwardHierIterator::operator++() {
+  auto&     frame     = stack_.back();
+  const Nid cur_nid   = (*frame.it).get_debug_nid();
+  const auto& entry   = frame.graph->node_table[static_cast<size_t>(cur_nid >> 2)];
+  const auto* lib     = frame.graph->owner_lib_;
+  ++frame.it;
+  if (entry.has_subnode() && lib != nullptr) {
+    const Gid sub = entry.get_subnode();
+    if (lib->has_graph(sub) && active_graphs_.find(sub) == active_graphs_.end()) {
+      Graph*         child     = const_cast<Graph*>(lib->get_graph(sub).get());
+      auto           it        = frame.graph->subnode_tree_pos_.find(cur_nid);
+      const Tree_pos child_pos = (it != frame.graph->subnode_tree_pos_.end()) ? it->second : static_cast<Tree_pos>(ROOT);
+      active_graphs_.insert(sub);
+      stack_.push_back(Frame{child, BackwardClassIterator(child), child_pos});
+    }
+  }
+  advance();
+  return *this;
+}
+
+BackwardHierIterator BackwardHierRange::begin() const { return BackwardHierIterator(graph_); }
 
 // --- Hier_instance members ---
 

--- a/hhds/graph.hpp
+++ b/hhds/graph.hpp
@@ -73,6 +73,12 @@ class ForwardFlatIterator;
 class ForwardFlatRange;
 class ForwardHierIterator;
 class ForwardHierRange;
+class BackwardClassIterator;
+class BackwardClassRange;
+class BackwardFlatIterator;
+class BackwardFlatRange;
+class BackwardHierIterator;
+class BackwardHierRange;
 class Hier_instance;
 class HierIterator;
 class HierRange;
@@ -510,6 +516,9 @@ public:
   [[nodiscard]] ForwardFlatRange  forward_flat() const noexcept;
   [[nodiscard]] FastHierRange     fast_hier() const noexcept;
   [[nodiscard]] ForwardHierRange  forward_hier() const noexcept;
+  [[nodiscard]] BackwardClassRange backward_class() const noexcept;
+  [[nodiscard]] BackwardFlatRange  backward_flat() const noexcept;
+  [[nodiscard]] BackwardHierRange  backward_hier() const noexcept;
   // Hierarchy-only traversal: yields one Hier_instance per subnode in the
   // structure tree, recursing into each instance's target graph (cycle-
   // guarded by active_graphs). Walks tree_ alone — it never iterates
@@ -584,6 +593,10 @@ private:
   // Exposed to the Forward iterator classes (which are friends).
   [[nodiscard]] bool forward_is_source(size_t idx) const noexcept;
 
+  void ensure_backward_caches() const;
+  // Exposed to the Backward iterator classes (which are friends).
+  [[nodiscard]] bool backward_is_sink(size_t idx) const noexcept;
+
   std::vector<NodeEntry>                         node_table;
   std::vector<PinEntry>                          pin_table;
   OverflowVec                                    overflow_sets_;
@@ -609,6 +622,9 @@ private:
   mutable std::vector<Nid>                       forward_pass2_cache_;
   mutable std::vector<uint32_t>                  forward_remaining_in_cache_;
   mutable bool                                   forward_caches_valid_ = false;
+  mutable std::vector<Nid>                       backward_pass2_cache_;
+  mutable std::vector<uint32_t>                  backward_remaining_out_cache_;
+  mutable bool                                   backward_caches_valid_ = false;
   ankerl::unordered_dense::map<std::string, Pid> input_pins_;
   ankerl::unordered_dense::map<std::string, Pid> output_pins_;
   const GraphLibrary*                            owner_lib_ = nullptr;
@@ -635,6 +651,12 @@ private:
   friend class ForwardFlatRange;
   friend class ForwardHierIterator;
   friend class ForwardHierRange;
+  friend class BackwardClassIterator;
+  friend class BackwardClassRange;
+  friend class BackwardFlatIterator;
+  friend class BackwardFlatRange;
+  friend class BackwardHierIterator;
+  friend class BackwardHierRange;
   friend class HierIterator;
   friend class HierRange;
   friend class Hier_instance;
@@ -954,6 +976,167 @@ public:
   explicit ForwardHierRange(Graph* graph) noexcept : graph_(graph) {}
   [[nodiscard]] ForwardHierIterator begin() const;
   [[nodiscard]] ForwardHierIterator end() const noexcept { return ForwardHierIterator{}; }
+
+private:
+  Graph* graph_;
+};
+
+// Backward topological iterator for a single graph body. Emits sinks first,
+// then reverse storage-order combinational nodes (Pass 1), then deferred back-edge
+// sources (Pass 2 replayed from Graph::backward_pass2_cache_), then any cycle
+// survivors (Tail).
+class BackwardClassIterator {
+public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type        = Node_class;
+  using difference_type   = std::ptrdiff_t;
+  using pointer           = void;
+  using reference         = Node_class;
+
+  BackwardClassIterator() noexcept = default;
+  BackwardClassIterator(const BackwardClassIterator&)            = delete;
+  BackwardClassIterator& operator=(const BackwardClassIterator&) = delete;
+  BackwardClassIterator(BackwardClassIterator&&) noexcept;
+  BackwardClassIterator& operator=(BackwardClassIterator&&) noexcept;
+  ~BackwardClassIterator() = default;
+
+  [[nodiscard]] Node_class operator*() const;
+  BackwardClassIterator&   operator++();
+  [[nodiscard]] bool operator==(const BackwardClassIterator& o) const noexcept {
+    if (phase_ == Phase::End && o.phase_ == Phase::End) {
+      return true;
+    }
+    return graph_ == o.graph_ && phase_ == o.phase_ && current_idx_ == o.current_idx_;
+  }
+  [[nodiscard]] bool operator!=(const BackwardClassIterator& o) const noexcept { return !(*this == o); }
+
+private:
+  enum class Phase : uint8_t { Pass1, Pass2, Tail, End };
+
+  explicit BackwardClassIterator(Graph* graph);
+  void advance();
+  void propagate(size_t sink_idx, size_t cursor);
+  [[nodiscard]] bool is_sink(size_t idx) const noexcept;
+  [[nodiscard]] bool is_emitted(size_t idx) const noexcept;
+  void               mark_emitted(size_t idx) noexcept;
+
+  Graph* graph_       = nullptr;
+  Phase  phase_       = Phase::End;
+  size_t idx_         = 0;
+  size_t pass2_head_  = 0;
+  size_t node_count_  = 0;
+  size_t current_idx_ = 0;
+
+  std::vector<uint32_t> working_remaining_out_;
+  std::vector<uint64_t> emitted_bits_;
+
+  friend class BackwardClassRange;
+  friend class BackwardFlatIterator;
+  friend class BackwardHierIterator;
+};
+
+class BackwardClassRange {
+public:
+  explicit BackwardClassRange(Graph* graph) noexcept : graph_(graph) {}
+  [[nodiscard]] BackwardClassIterator begin() const;
+  [[nodiscard]] BackwardClassIterator end() const noexcept { return BackwardClassIterator{}; }
+
+  [[nodiscard]] size_t     size() const;
+  [[nodiscard]] Node_class front() const;
+  [[nodiscard]] bool       empty() const;
+
+private:
+  Graph* graph_;
+};
+
+class BackwardFlatIterator {
+public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type        = Node_class;
+  using difference_type   = std::ptrdiff_t;
+  using pointer           = void;
+  using reference         = Node_class;
+
+  BackwardFlatIterator() noexcept = default;
+  BackwardFlatIterator(const BackwardFlatIterator&)            = delete;
+  BackwardFlatIterator& operator=(const BackwardFlatIterator&) = delete;
+  BackwardFlatIterator(BackwardFlatIterator&&) noexcept        = default;
+  BackwardFlatIterator& operator=(BackwardFlatIterator&&) noexcept = default;
+  ~BackwardFlatIterator()                                          = default;
+
+  [[nodiscard]] Node_class operator*() const;
+  BackwardFlatIterator&    operator++();
+  [[nodiscard]] bool operator==(const BackwardFlatIterator& o) const noexcept { return stack_.empty() && o.stack_.empty(); }
+  [[nodiscard]] bool operator!=(const BackwardFlatIterator& o) const noexcept { return !(*this == o); }
+
+private:
+  struct Frame {
+    Graph*                graph;
+    BackwardClassIterator it;
+  };
+
+  explicit BackwardFlatIterator(Graph* root_graph);
+  void advance();
+
+  Gid                               top_graph_ = Gid_invalid;
+  std::vector<Frame>                stack_;
+  ankerl::unordered_dense::set<Gid> active_graphs_;
+
+  friend class BackwardFlatRange;
+};
+
+class BackwardFlatRange {
+public:
+  explicit BackwardFlatRange(Graph* graph) noexcept : graph_(graph) {}
+  [[nodiscard]] BackwardFlatIterator begin() const;
+  [[nodiscard]] BackwardFlatIterator end() const noexcept { return BackwardFlatIterator{}; }
+
+private:
+  Graph* graph_;
+};
+
+class BackwardHierIterator {
+public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type        = Node_class;
+  using difference_type   = std::ptrdiff_t;
+  using pointer           = void;
+  using reference         = Node_class;
+
+  BackwardHierIterator() noexcept = default;
+  BackwardHierIterator(const BackwardHierIterator&)            = delete;
+  BackwardHierIterator& operator=(const BackwardHierIterator&) = delete;
+  BackwardHierIterator(BackwardHierIterator&&) noexcept        = default;
+  BackwardHierIterator& operator=(BackwardHierIterator&&) noexcept = default;
+  ~BackwardHierIterator()                                          = default;
+
+  [[nodiscard]] Node_class operator*() const;
+  BackwardHierIterator&    operator++();
+  [[nodiscard]] bool operator==(const BackwardHierIterator& o) const noexcept { return stack_.empty() && o.stack_.empty(); }
+  [[nodiscard]] bool operator!=(const BackwardHierIterator& o) const noexcept { return !(*this == o); }
+
+private:
+  struct Frame {
+    Graph*                graph;
+    BackwardClassIterator it;
+    Tree_pos              hier_pos;
+  };
+
+  explicit BackwardHierIterator(Graph* root_graph);
+  void advance();
+
+  Gid                               root_gid_ = Gid_invalid;
+  std::vector<Frame>                stack_;
+  ankerl::unordered_dense::set<Gid> active_graphs_;
+
+  friend class BackwardHierRange;
+};
+
+class BackwardHierRange {
+public:
+  explicit BackwardHierRange(Graph* graph) noexcept : graph_(graph) {}
+  [[nodiscard]] BackwardHierIterator begin() const;
+  [[nodiscard]] BackwardHierIterator end() const noexcept { return BackwardHierIterator{}; }
 
 private:
   Graph* graph_;

--- a/hhds/tests/graph_test.cpp
+++ b/hhds/tests/graph_test.cpp
@@ -1,15 +1,35 @@
 #include "hhds/graph.hpp"
 
-#include <cassert>
-#include <csignal>
 #include <fcntl.h>
-#include <iostream>
-#include <string>
 #include <sys/wait.h>
 #include <unistd.h>
+
+#include <cassert>
+#include <csignal>
+#include <iostream>
+#include <string>
+#include <utility>
 #include <vector>
 
 namespace {
+
+template <typename Range>
+std::vector<hhds::Nid> collect_nids(Range&& range) {
+  std::vector<hhds::Nid> order;
+  for (auto node : range) {
+    order.push_back(node.get_debug_nid());
+  }
+  return order;
+}
+
+template <typename Range>
+std::vector<std::pair<hhds::Gid, hhds::Nid>> collect_gid_nids(Range&& range) {
+  std::vector<std::pair<hhds::Gid, hhds::Nid>> order;
+  for (auto node : range) {
+    order.emplace_back(node.get_current_gid(), node.get_debug_nid());
+  }
+  return order;
+}
 
 void test_declaration_api() {
   hhds::GraphLibrary lib;
@@ -91,6 +111,28 @@ void test_forward_class_returns_wrappers() {
   assert(order[2] == n2.get_debug_nid());
 }
 
+void test_backward_class_returns_wrappers() {
+  hhds::GraphLibrary lib;
+  auto               gio   = lib.create_io("top");
+  auto               graph = gio->create_graph();
+
+  auto n1 = graph->create_node();
+  auto n2 = graph->create_node();
+  n1.create_driver_pin().connect_sink(n2.create_sink_pin());
+
+  std::vector<hhds::Nid> order;
+  for (auto node : graph->backward_class()) {
+    assert(node.get_graph() == graph.get());
+    assert(node.is_class());
+    order.push_back(node.get_debug_nid());
+  }
+
+  assert(order.size() == 3);
+  assert(order[0] == n2.get_debug_nid());
+  assert(order[1] == n1.get_debug_nid());
+  assert(order[2] == hhds::Graph::CONST_NODE);
+}
+
 void test_traversal_contexts_use_one_node_type() {
   hhds::GraphLibrary lib;
   auto               leaf_io = lib.create_io("leaf");
@@ -130,6 +172,29 @@ void test_traversal_contexts_use_one_node_type() {
     }
   }
   assert(saw_hier_leaf);
+
+  bool saw_backward_flat_leaf = false;
+  for (auto node : top->backward_flat()) {
+    assert(node.is_flat());
+    assert(!node.is_hier());
+    if (node.get_debug_nid() == leaf_n.get_debug_nid()) {
+      auto pin = node.create_sink_pin();
+      assert(pin.is_flat());
+      saw_backward_flat_leaf = true;
+    }
+  }
+  assert(saw_backward_flat_leaf);
+
+  bool saw_backward_hier_leaf = false;
+  for (auto node : top->backward_hier()) {
+    assert(node.is_hier());
+    if (node.get_debug_nid() == leaf_n.get_debug_nid()) {
+      auto pin = node.create_driver_pin();
+      assert(pin.is_hier());
+      saw_backward_hier_leaf = true;
+    }
+  }
+  assert(saw_backward_hier_leaf);
 }
 
 void test_forward_loop_last_is_source() {
@@ -167,6 +232,31 @@ void test_forward_loop_last_is_source() {
   assert(order[3] == n3.get_debug_nid());
 }
 
+void test_backward_loop_last_is_sink() {
+  hhds::GraphLibrary lib;
+  auto               gio   = lib.create_io("top");
+  auto               graph = gio->create_graph();
+
+  auto n1 = graph->create_node();
+  auto n2 = graph->create_node();
+  auto n3 = graph->create_node();
+  n3.set_type(3);  // bit 0 set -> is_loop_last
+
+  n1.create_driver_pin().connect_sink(n2.create_sink_pin());
+  n2.create_driver_pin().connect_sink(n3.create_sink_pin());
+  n3.create_driver_pin().connect_sink(n2.create_sink_pin());
+
+  std::vector<hhds::Nid> order;
+  for (auto node : graph->backward_class()) {
+    order.push_back(node.get_debug_nid());
+  }
+  assert(order.size() == 4);
+  assert(order[0] == n3.get_debug_nid());
+  assert(order[1] == n2.get_debug_nid());
+  assert(order[2] == n1.get_debug_nid());
+  assert(order[3] == hhds::Graph::CONST_NODE);
+}
+
 void test_forward_out_of_order_uses_pending_list() {
   // Exercises Pass 2: a driver created AFTER its sink in storage order.
   // Pass 1 skips the sink (count > 0), emits the driver, decrements the
@@ -191,6 +281,240 @@ void test_forward_out_of_order_uses_pending_list() {
   assert(order[1] == n3.get_debug_nid());
   assert(order[2] == n1.get_debug_nid());
   assert(order[3] == n2.get_debug_nid());
+}
+
+void test_backward_out_of_order_uses_pending_list() {
+  hhds::GraphLibrary lib;
+  auto               gio   = lib.create_io("top");
+  auto               graph = gio->create_graph();
+
+  auto n1 = graph->create_node();
+  auto n2 = graph->create_node();
+  auto n3 = graph->create_node();
+
+  n1.create_driver_pin().connect_sink(n2.create_sink_pin());
+  n3.create_driver_pin().connect_sink(n1.create_sink_pin());
+
+  std::vector<hhds::Nid> order;
+  for (auto node : graph->backward_class()) {
+    order.push_back(node.get_debug_nid());
+  }
+  assert(order.size() == 4);
+  assert(order[0] == n2.get_debug_nid());
+  assert(order[1] == n1.get_debug_nid());
+  assert(order[2] == hhds::Graph::CONST_NODE);
+  assert(order[3] == n3.get_debug_nid());
+}
+
+void test_backward_cache_invalidates_after_set_type() {
+  // Cycle n1<->n2 with no loop_last: both nodes fall through to the Tail
+  // phase (Pass 1 and Pass 2 can't break the cycle), so order is
+  // [CONST, n2, n1]. After set_type marks n2 as loop_last, n2 becomes a
+  // sink: Pass 1 emits it first and frees n1's count, yielding [n2, n1, CONST].
+  // A stale cache would replay the old Tail-based order, so this test fails
+  // unless set_type invalidates backward_caches_valid_.
+  hhds::GraphLibrary lib;
+  auto               gio   = lib.create_io("top");
+  auto               graph = gio->create_graph();
+
+  auto n1 = graph->create_node();
+  auto n2 = graph->create_node();
+
+  n1.create_driver_pin().connect_sink(n2.create_sink_pin());
+  n2.create_driver_pin().connect_sink(n1.create_sink_pin());
+
+  const std::vector<hhds::Nid> before{hhds::Graph::CONST_NODE, n2.get_debug_nid(), n1.get_debug_nid()};
+  assert(collect_nids(graph->backward_class()) == before);
+
+  n2.set_type(3);
+  assert(n2.is_loop_last());
+
+  const std::vector<hhds::Nid> after{n2.get_debug_nid(), n1.get_debug_nid(), hhds::Graph::CONST_NODE};
+  assert(collect_nids(graph->backward_class()) == after);
+}
+
+void test_backward_cache_invalidates_after_edge_mutation() {
+  hhds::GraphLibrary lib;
+  auto               gio   = lib.create_io("top");
+  auto               graph = gio->create_graph();
+
+  auto n1 = graph->create_node();
+  auto n2 = graph->create_node();
+  auto n3 = graph->create_node();
+
+  const std::vector<hhds::Nid> initial{n3.get_debug_nid(), n2.get_debug_nid(), n1.get_debug_nid(), hhds::Graph::CONST_NODE};
+  assert(collect_nids(graph->backward_class()) == initial);
+
+  n3.create_driver_pin().connect_sink(n1.create_sink_pin());
+
+  const std::vector<hhds::Nid> after_edge{n2.get_debug_nid(), n1.get_debug_nid(), hhds::Graph::CONST_NODE, n3.get_debug_nid()};
+  assert(collect_nids(graph->backward_class()) == after_edge);
+}
+
+void test_backward_diamond_fan_in() {
+  // Diamond: n1 fans out to n2 and n3, both feed n4.
+  // remaining_out: n1=2, n2=1, n3=1, n4=0. Pass 1 reverse emits n4 (sink),
+  // then n3 and n2 (counts hit zero in storage-reverse order), then n1.
+  hhds::GraphLibrary lib;
+  auto               gio   = lib.create_io("top");
+  auto               graph = gio->create_graph();
+
+  auto n1 = graph->create_node();
+  auto n2 = graph->create_node();
+  auto n3 = graph->create_node();
+  auto n4 = graph->create_node();
+
+  n1.create_driver_pin().connect_sink(n2.create_sink_pin());
+  n1.create_driver_pin().connect_sink(n3.create_sink_pin());
+  n2.create_driver_pin().connect_sink(n4.create_sink_pin());
+  n3.create_driver_pin().connect_sink(n4.create_sink_pin());
+
+  const std::vector<hhds::Nid> expected{
+      n4.get_debug_nid(),
+      n3.get_debug_nid(),
+      n2.get_debug_nid(),
+      n1.get_debug_nid(),
+      hhds::Graph::CONST_NODE,
+  };
+  assert(collect_nids(graph->backward_class()) == expected);
+}
+
+void test_backward_named_pin_and_declared_io_edges() {
+  hhds::GraphLibrary lib;
+  auto               gio = lib.create_io("top");
+  gio->add_input("in", 1);
+  gio->add_output("out", 2);
+  auto graph = gio->create_graph();
+
+  auto n1 = graph->create_node();
+  auto n2 = graph->create_node();
+
+  graph->get_input_pin("in").connect_sink(n1.create_sink_pin(11));
+  n1.create_driver_pin(7).connect_sink(n2.create_sink_pin(8));
+  n2.create_driver_pin(9).connect_sink(graph->get_output_pin("out"));
+
+  const std::vector<hhds::Nid> expected{n2.get_debug_nid(), n1.get_debug_nid(), hhds::Graph::CONST_NODE};
+  assert(collect_nids(graph->backward_class()) == expected);
+}
+
+void test_backward_skips_tombstones_after_delete() {
+  hhds::GraphLibrary lib;
+  auto               gio   = lib.create_io("top");
+  auto               graph = gio->create_graph();
+
+  auto n1 = graph->create_node();
+  auto n2 = graph->create_node();
+  auto n3 = graph->create_node();
+
+  const std::vector<hhds::Nid> initial{n3.get_debug_nid(), n2.get_debug_nid(), n1.get_debug_nid(), hhds::Graph::CONST_NODE};
+  assert(collect_nids(graph->backward_class()) == initial);
+
+  n2.del_node();
+
+  const std::vector<hhds::Nid> after_delete{n3.get_debug_nid(), n1.get_debug_nid(), hhds::Graph::CONST_NODE};
+  assert(collect_nids(graph->backward_class()) == after_delete);
+}
+
+void test_backward_cycle_tail_without_loop_last() {
+  hhds::GraphLibrary lib;
+  auto               gio   = lib.create_io("top");
+  auto               graph = gio->create_graph();
+
+  auto n1 = graph->create_node();
+  auto n2 = graph->create_node();
+
+  n1.create_driver_pin().connect_sink(n2.create_sink_pin());
+  n2.create_driver_pin().connect_sink(n1.create_sink_pin());
+
+  const std::vector<hhds::Nid> expected{hhds::Graph::CONST_NODE, n2.get_debug_nid(), n1.get_debug_nid()};
+  assert(collect_nids(graph->backward_class()) == expected);
+}
+
+void test_backward_flat_exact_order_and_shared_body_dedup() {
+  hhds::GraphLibrary lib;
+
+  auto leaf_io = lib.create_io("leaf");
+  auto leaf    = leaf_io->create_graph();
+  auto leaf_n1 = leaf->create_node();
+  auto leaf_n2 = leaf->create_node();
+  leaf_n1.create_driver_pin().connect_sink(leaf_n2.create_sink_pin());
+
+  auto top_io = lib.create_io("top");
+  auto top    = top_io->create_graph();
+  auto inst1  = top->create_node();
+  auto inst2  = top->create_node();
+  inst1.set_subnode(leaf_io);
+  inst2.set_subnode(leaf_io);
+
+  const std::vector<std::pair<hhds::Gid, hhds::Nid>> expected{
+      {top->get_gid(), inst2.get_debug_nid()},
+      {leaf->get_gid(), leaf_n2.get_debug_nid()},
+      {leaf->get_gid(), leaf_n1.get_debug_nid()},
+      {leaf->get_gid(), hhds::Graph::CONST_NODE},
+      {top->get_gid(), inst1.get_debug_nid()},
+      {top->get_gid(), hhds::Graph::CONST_NODE},
+  };
+  assert(collect_gid_nids(top->backward_flat()) == expected);
+}
+
+void test_backward_hier_exact_order_and_shared_body_per_instance() {
+  hhds::GraphLibrary lib;
+
+  auto leaf_io = lib.create_io("leaf");
+  auto leaf    = leaf_io->create_graph();
+  auto leaf_n1 = leaf->create_node();
+  auto leaf_n2 = leaf->create_node();
+  leaf_n1.create_driver_pin().connect_sink(leaf_n2.create_sink_pin());
+
+  auto top_io = lib.create_io("top");
+  auto top    = top_io->create_graph();
+  auto inst1  = top->create_node();
+  auto inst2  = top->create_node();
+  inst1.set_subnode(leaf_io);
+  inst2.set_subnode(leaf_io);
+
+  const std::vector<std::pair<hhds::Gid, hhds::Nid>> expected{
+      {top->get_gid(), inst2.get_debug_nid()},
+      {leaf->get_gid(), leaf_n2.get_debug_nid()},
+      {leaf->get_gid(), leaf_n1.get_debug_nid()},
+      {leaf->get_gid(), hhds::Graph::CONST_NODE},
+      {top->get_gid(), inst1.get_debug_nid()},
+      {leaf->get_gid(), leaf_n2.get_debug_nid()},
+      {leaf->get_gid(), leaf_n1.get_debug_nid()},
+      {leaf->get_gid(), hhds::Graph::CONST_NODE},
+      {top->get_gid(), hhds::Graph::CONST_NODE},
+  };
+  assert(collect_gid_nids(top->backward_hier()) == expected);
+}
+
+void test_backward_hier_descends_into_nested_subnodes() {
+  // 3-level nesting: top -> mid -> leaf. backward_hier from top must yield
+  // each instance node first, then recurse into its body in backward order,
+  // popping back to the parent's CONST. Mirrors the forward
+  // test_hier_range_descends_into_nested_subnodes shape.
+  hhds::GraphLibrary lib;
+
+  auto leaf_gio = lib.create_io("leaf");
+  auto leaf     = leaf_gio->create_graph();
+
+  auto mid_gio          = lib.create_io("mid");
+  auto mid              = mid_gio->create_graph();
+  auto mid_inst_of_leaf = mid->create_node();
+  mid_inst_of_leaf.set_subnode(leaf_gio);
+
+  auto top_gio         = lib.create_io("top");
+  auto top             = top_gio->create_graph();
+  auto top_inst_of_mid = top->create_node();
+  top_inst_of_mid.set_subnode(mid_gio);
+
+  const std::vector<std::pair<hhds::Gid, hhds::Nid>> expected{
+      {top->get_gid(), top_inst_of_mid.get_debug_nid()},
+      {mid->get_gid(), mid_inst_of_leaf.get_debug_nid()},
+      {leaf->get_gid(), hhds::Graph::CONST_NODE},
+      {mid->get_gid(), hhds::Graph::CONST_NODE},
+      {top->get_gid(), hhds::Graph::CONST_NODE},
+  };
+  assert(collect_gid_nids(top->backward_hier()) == expected);
 }
 
 void test_subnode_with_loop_last_pin_marks_node() {
@@ -226,10 +550,10 @@ void test_hier_range_flat_graph_is_empty() {
   // A graph with no subnodes should produce an empty hier_range — even when
   // it has plain (non-subnode) graph nodes and IO pins.
   hhds::GraphLibrary lib;
-  auto               gio   = lib.create_io("flat");
+  auto               gio = lib.create_io("flat");
   gio->add_input("in", 0);
   gio->add_output("out", 0);
-  auto               graph = gio->create_graph();
+  auto graph = gio->create_graph();
   (void)graph->create_node();
   (void)graph->create_node();
 
@@ -289,13 +613,13 @@ void test_hier_range_descends_into_nested_subnodes() {
   auto leaf_gio = lib.create_io("leaf");
   (void)leaf_gio->create_graph();
 
-  auto mid_gio = lib.create_io("mid");
-  auto mid     = mid_gio->create_graph();
+  auto mid_gio          = lib.create_io("mid");
+  auto mid              = mid_gio->create_graph();
   auto mid_inst_of_leaf = mid->create_node();
   mid_inst_of_leaf.set_subnode(leaf_gio);
 
-  auto top_gio = lib.create_io("top");
-  auto top     = top_gio->create_graph();
+  auto top_gio         = lib.create_io("top");
+  auto top             = top_gio->create_graph();
   auto top_inst_of_mid = top->create_node();
   top_inst_of_mid.set_subnode(mid_gio);
 
@@ -360,13 +684,13 @@ void test_set_subnode_linear_deep_chain_ok() {
   // Linear chain a -> b -> c -> d. No cycle, so set_subnode must succeed
   // at every level. Walking a's hier_range yields 3 instances.
   hhds::GraphLibrary lib;
-  auto a_gio = lib.create_io("a");
-  auto a     = a_gio->create_graph();
-  auto b_gio = lib.create_io("b");
-  auto b     = b_gio->create_graph();
-  auto c_gio = lib.create_io("c");
-  auto c     = c_gio->create_graph();
-  auto d_gio = lib.create_io("d");
+  auto               a_gio = lib.create_io("a");
+  auto               a     = a_gio->create_graph();
+  auto               b_gio = lib.create_io("b");
+  auto               b     = b_gio->create_graph();
+  auto               c_gio = lib.create_io("c");
+  auto               c     = c_gio->create_graph();
+  auto               d_gio = lib.create_io("d");
   (void)d_gio->create_graph();
 
   a->create_node().set_subnode(b_gio);
@@ -386,13 +710,13 @@ void test_set_subnode_diamond_ok() {
   // leaf. This is a DAG (leaf is reached two ways), not a cycle —
   // would_create_cycle must return false for every set_subnode call here.
   hhds::GraphLibrary lib;
-  auto top_gio  = lib.create_io("top");
-  auto top      = top_gio->create_graph();
-  auto b1_gio   = lib.create_io("b1");
-  auto b1       = b1_gio->create_graph();
-  auto b2_gio   = lib.create_io("b2");
-  auto b2       = b2_gio->create_graph();
-  auto leaf_gio = lib.create_io("leaf");
+  auto               top_gio  = lib.create_io("top");
+  auto               top      = top_gio->create_graph();
+  auto               b1_gio   = lib.create_io("b1");
+  auto               b1       = b1_gio->create_graph();
+  auto               b2_gio   = lib.create_io("b2");
+  auto               b2       = b2_gio->create_graph();
+  auto               leaf_gio = lib.create_io("leaf");
   (void)leaf_gio->create_graph();
 
   top->create_node().set_subnode(b1_gio);
@@ -468,9 +792,9 @@ void test_set_subnode_retarget_ok() {
   // structure tree retains a single child for this subnode, retargeted
   // to the new gid.
   hhds::GraphLibrary lib;
-  auto a_gio = lib.create_io("a");
-  auto a     = a_gio->create_graph();
-  auto b_gio = lib.create_io("b");
+  auto               a_gio = lib.create_io("a");
+  auto               a     = a_gio->create_graph();
+  auto               b_gio = lib.create_io("b");
   (void)b_gio->create_graph();
   auto c_gio = lib.create_io("c");
   (void)c_gio->create_graph();
@@ -479,7 +803,7 @@ void test_set_subnode_retarget_ok() {
   inst.set_subnode(b_gio);
   inst.set_subnode(c_gio);
 
-  size_t   count       = 0;
+  size_t    count       = 0;
   hhds::Gid last_target = hhds::Gid_invalid;
   for (auto h : a->hier_range()) {
     last_target = h.get_target_gid();
@@ -495,9 +819,21 @@ int main() {
   test_declaration_api();
   test_wrapper_pin_connect_api();
   test_forward_class_returns_wrappers();
+  test_backward_class_returns_wrappers();
   test_traversal_contexts_use_one_node_type();
   test_forward_loop_last_is_source();
+  test_backward_loop_last_is_sink();
   test_forward_out_of_order_uses_pending_list();
+  test_backward_out_of_order_uses_pending_list();
+  test_backward_cache_invalidates_after_set_type();
+  test_backward_cache_invalidates_after_edge_mutation();
+  test_backward_diamond_fan_in();
+  test_backward_named_pin_and_declared_io_edges();
+  test_backward_skips_tombstones_after_delete();
+  test_backward_cycle_tail_without_loop_last();
+  test_backward_flat_exact_order_and_shared_body_dedup();
+  test_backward_hier_exact_order_and_shared_body_per_instance();
+  test_backward_hier_descends_into_nested_subnodes();
   test_subnode_with_loop_last_pin_marks_node();
   test_hier_range_flat_graph_is_empty();
   test_hier_range_yields_one_per_subnode();

--- a/hhds/tests/iterators_impl.cpp
+++ b/hhds/tests/iterators_impl.cpp
@@ -75,6 +75,31 @@ TEST(GraphTraversalApi, ForwardClassUsesNodeWrappers) {
   EXPECT_EQ(order[3], n3.get_debug_nid());
 }
 
+TEST(GraphTraversalApi, BackwardClassUsesNodeWrappers) {
+  hhds::GraphLibrary lib;
+  auto               gio   = lib.create_io("top");
+  auto               graph = gio->create_graph();
+
+  auto n1 = graph->create_node();
+  auto n2 = graph->create_node();
+  auto n3 = graph->create_node();
+
+  n1.create_driver_pin().connect_sink(n2.create_sink_pin());
+  n2.create_driver_pin().connect_sink(n3.create_sink_pin());
+
+  std::vector<hhds::Nid> order;
+  for (auto node : graph->backward_class()) {
+    EXPECT_EQ(node.get_graph(), graph.get());
+    order.push_back(node.get_debug_nid());
+  }
+
+  ASSERT_EQ(order.size(), 4);
+  EXPECT_EQ(order[0], n3.get_debug_nid());
+  EXPECT_EQ(order[1], n2.get_debug_nid());
+  EXPECT_EQ(order[2], n1.get_debug_nid());
+  EXPECT_EQ(order[3], hhds::Graph::CONST_NODE);
+}
+
 TEST(TreeDeclarationApi, CreateFindAndNavigate) {
   auto forest = hhds::Forest::create();
   auto tio    = forest->create_io("tree");


### PR DESCRIPTION
## Summary

- Adds `backward_class()`, `backward_flat()`, and `backward_hier()` to `hhds::Graph`, mirroring the existing forward iterator family.
- Reverse-topological emission: sinks first (incl. `loop_last` nodes and the OUTPUT node), then nodes in storage-reverse order as their out-edge counts drain, with cycle survivors picked up by a Tail phase.
- Caches `backward_pass2_cache_` and `backward_remaining_out_cache_` are built once per dirty pass and reused across iterations. `invalidate_traversal_caches()` and `invalidate_from_library()` now reset them alongside the forward caches.
- Fixes a latent cache-staleness bug: `Node_class::set_type` did not invalidate traversal caches, even though `loop_last` (low bit of type) affects both forward `is_source` and backward `is_sink`. Both directions now re-build their caches after a type change.

## Implementation notes

- `BackwardClassIterator` runs the same three-phase algorithm as `ForwardClassIterator` — Pass 1 walks storage in reverse, Pass 2 replays a deferred-emit cache populated at cache-build time, Tail sweeps any remaining cycle survivors.
- `BackwardFlatIterator` uses a single `active_graphs_` set across the entire traversal, so each unique subnode body is visited once even when instantiated multiple times.
- `BackwardHierIterator` erases the graph from `active_graphs_` on frame pop, so each instance descends into its body even when the same body is reused.

## Test plan

- [x] `bazel test //hhds:graph_test` — assert-based tests (extended)
- [x] `bazel test //hhds:iterators_impl` — gtest target (extended)

New tests in `graph_test.cpp`:
- `test_backward_class_returns_wrappers` — basic 2-node linear, asserts `[n2, n1, CONST]`.
- `test_backward_loop_last_is_sink` — `loop_last` node acts as a sink in Pass 1.
- `test_backward_out_of_order_uses_pending_list` — Pass 2 deferred-emit path.
- `test_backward_cache_invalidates_after_set_type` — cycle `n1↔n2`, then `set_type(loop_last)` on n2 changes the order from `[CONST, n2, n1]` (Tail) to `[n2, n1, CONST]` (Pass 1). Detects stale cache.
- `test_backward_cache_invalidates_after_edge_mutation` — adding an edge between iterations changes the emitted order.
- `test_backward_diamond_fan_in` — `n1→{n2,n3}→n4` exercises multi-driver `propagate()`.
- `test_backward_named_pin_and_declared_io_edges` — non-default named pins and declared graph IO.
- `test_backward_skips_tombstones_after_delete` — deleted nodes are skipped.
- `test_backward_cycle_tail_without_loop_last` — true cycle, Tail phase emits both nodes.
- `test_backward_flat_exact_order_and_shared_body_dedup` — two instances of the same body, flat visits the body once.
- `test_backward_hier_exact_order_and_shared_body_per_instance` — two instances of the same body, hier visits the body twice.
- `test_backward_hier_descends_into_nested_subnodes` — 3-level `top→mid→leaf` nesting, full descend/pop sequence.

New tests in `iterators_impl.cpp`:
- `TEST(GraphTraversalApi, BackwardClassUsesNodeWrappers)` — gtest parity with the existing forward test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added backward graph traversal support with class, flat, and hierarchical iteration modes
  * Added comprehensive benchmarking suite for graph operations with multiple topologies and analysis tools
  * Added benchmark visualization and reporting capabilities (plotting, table generation, automated sweeps)

* **Tests**
  * Expanded graph traversal test coverage for backward iteration validation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/masc-ucsc/hhds/pull/213)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->