### PR TITLE
Report final benchmark results as ns/op

### DIFF
--- a/hhds/benchmarks_final/README.md
+++ b/hhds/benchmarks_final/README.md
@@ -7,9 +7,11 @@ Layout:
 
 - `hhds/`: HHDS benchmark binary and raw `results.csv`.
 - `boost/`: Boost.Graph benchmark binary and raw `results.csv`.
-- `livehd/`: reserved LiveHD slot. It is `N/A` until LiveHD source is available.
+- `livehd/`: LiveHD result slot. `run_all.sh` fills it when a sibling LiveHD
+  checkout with `//lgraph:livehd_final_bench` is available.
 - `comparisons/comparison.csv`: wide table with `operation`, `hhds`, `livehd`,
-  and `boost` columns. Times are median wall time in milliseconds.
+  and `boost` columns. Times are median nanoseconds per operation (`ns/op`),
+  computed as `wall_ns / items` for each raw run.
 - `comparisons/plot/`: one PNG per operation/scenario.
 - `scripts/run_all.sh`: builds, runs, aggregates, and plots.
 
@@ -24,3 +26,10 @@ a DAG version of the same forward-K shape so Boost topological traversal remains
 valid. The edge creation/deletion and `traverse_fast_class` scenarios use the
 ring shape to make every node land in the intended storage tier.
 
+LiveHD notes:
+
+- Set `LIVEHD_ROOT=/path/to/livehd` if LiveHD is not checked out next to this
+  HHDS repo.
+- LiveHD backward traversal rows are `N/A` because LiveHD's `backward()`
+  implementation currently contains a FIXME/assert rather than a working
+  iterator.

--- a/hhds/benchmarks_final/livehd/README.md
+++ b/hhds/benchmarks_final/livehd/README.md
@@ -1,12 +1,25 @@
 LiveHD benchmark slot
 =====================
 
-This checkout does not contain a buildable LiveHD/lgraph source tree or target.
-The final benchmark scripts still create `livehd/results.csv` and the comparison
-CSV keeps a `livehd` column, but values are `N/A` until a real LiveHD benchmark
-binary is added here.
+`run_all.sh` can include LiveHD when a sibling LiveHD checkout exists and
+provides this binary:
 
-Do not fake LiveHD timings with another library. Once the real API is available,
-add a `livehd_final_bench` binary that writes the same raw CSV schema as the
-HHDS and Boost binaries.
+```text
+//lgraph:livehd_final_bench
+```
 
+Default expected path:
+
+```text
+/Users/hamidsadjadpour/Desktop/masc_ucsc/livehd
+```
+
+Override it with:
+
+```bash
+LIVEHD_ROOT=/path/to/livehd bash hhds/benchmarks_final/scripts/run_all.sh
+```
+
+The LiveHD binary must emit the same raw CSV schema as the HHDS and Boost
+binaries. Backward traversal rows remain `N/A` for LiveHD because LiveHD's
+`backward()` iterator is currently a stub with a FIXME/assert.

--- a/hhds/benchmarks_final/scripts/make_comparison.py
+++ b/hhds/benchmarks_final/scripts/make_comparison.py
@@ -43,6 +43,14 @@ SCENARIO_ORDER = {
 }
 
 
+def ns_per_op(row):
+    wall_ns = int(row["wall_ns"])
+    items = int(row["items"])
+    if items <= 0:
+        return None
+    return wall_ns / items
+
+
 def read_rows(path, rows_by_key):
     csv_path = Path(path)
     if not csv_path.exists():
@@ -60,7 +68,9 @@ def read_rows(path, rows_by_key):
                 int(row["x_value"]),
             )
             library = row["library"]
-            rows_by_key[key][library].append(int(row["wall_ns"]))
+            value = ns_per_op(row)
+            if value is not None:
+                rows_by_key[key][library].append(value)
 
 
 def sort_key(item):
@@ -68,10 +78,10 @@ def sort_key(item):
     return (OP_ORDER.get(operation, 1000), operation, SCENARIO_ORDER.get(scenario, 100), scenario, x_axis, x_value)
 
 
-def fmt_ms(values):
+def fmt_ns_per_op(values):
     if not values:
         return "N/A"
-    return f"{statistics.median(values) / 1_000_000.0:.6f}"
+    return f"{statistics.median(values):.3f}"
 
 
 def main():
@@ -93,8 +103,8 @@ def main():
       writer = csv.writer(handle)
       writer.writerow(["operation", "scenario", "x_axis", "x_value", "time_unit", "hhds", "livehd", "boost"])
       for key in sorted(rows_by_key, key=sort_key):
-          row = [key[0], key[1], key[2], key[3], "ms"]
-          row.extend(fmt_ms(rows_by_key[key].get(library, [])) for library in LIBRARIES)
+          row = [key[0], key[1], key[2], key[3], "ns/op"]
+          row.extend(fmt_ns_per_op(rows_by_key[key].get(library, [])) for library in LIBRARIES)
           writer.writerow(row)
 
 

--- a/hhds/benchmarks_final/scripts/plot_results.py
+++ b/hhds/benchmarks_final/scripts/plot_results.py
@@ -70,7 +70,8 @@ def main():
 
         ax.set_title(f"{operation} / {scenario}")
         ax.set_xlabel(x_axis.replace("_", " "))
-        ax.set_ylabel("median wall time (ms)")
+        time_unit = rows[0].get("time_unit", "ns/op")
+        ax.set_ylabel(f"median time ({time_unit})")
         ax.grid(True, which="both", linestyle="--", alpha=0.35)
         ax.legend()
         if all(int(row["x_value"]) > 0 for row in rows):

--- a/hhds/benchmarks_final/scripts/run_all.sh
+++ b/hhds/benchmarks_final/scripts/run_all.sh
@@ -7,6 +7,8 @@ BENCH_DIR="$REPO_ROOT/hhds/benchmarks_final"
 
 HHDS_BIN="$REPO_ROOT/bazel-bin/hhds/benchmarks_final/hhds/hhds_final_bench"
 BOOST_BIN="$REPO_ROOT/bazel-bin/hhds/benchmarks_final/boost/boost_final_bench"
+LIVEHD_ROOT="${LIVEHD_ROOT:-$(cd "$REPO_ROOT/.." && pwd)/livehd}"
+LIVEHD_BIN="$LIVEHD_ROOT/bazel-bin/lgraph/livehd_final_bench"
 
 HHDS_CSV="$BENCH_DIR/hhds/results.csv"
 BOOST_CSV="$BENCH_DIR/boost/results.csv"
@@ -31,6 +33,13 @@ fi
 
 cd "$REPO_ROOT"
 bazel build //hhds/benchmarks_final/hhds:hhds_final_bench //hhds/benchmarks_final/boost:boost_final_bench
+
+LIVEHD_AVAILABLE=0
+if [[ -f "$LIVEHD_ROOT/lgraph/tests/livehd_final_bench.cpp" ]]; then
+  echo "Building LiveHD benchmark..."
+  (cd "$LIVEHD_ROOT" && bazel build //lgraph:livehd_final_bench)
+  LIVEHD_AVAILABLE=1
+fi
 
 mkdir -p "$BENCH_DIR/hhds" "$BENCH_DIR/boost" "$BENCH_DIR/livehd" "$BENCH_DIR/comparisons" "$PLOT_DIR"
 HEADER="library,operation,scenario,x_axis,x_value,nodes,pins_per_node,hier_size,k,run_idx,wall_ns,items"
@@ -118,7 +127,47 @@ for scenario in sedges_inline ledge_inline overflow; do
   done
 done
 
-echo "LiveHD source is not present in this checkout; livehd/results.csv is intentionally header-only."
+if [[ "$LIVEHD_AVAILABLE" == "1" ]]; then
+  echo "Running LiveHD benchmarks..."
+  for nodes in $NODE_SIZES; do
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" add_nodes default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" add_nodes_with_pins default nodes "$nodes" 8 "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" lookup_nodes default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" delete_nodes_with_edges_and_pins default nodes "$nodes" 8 "$FIXED_HIER_SIZE" 0
+  done
+
+  for pins in $PIN_SIZES; do
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" add_pins default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" delete_pins default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" delete_pins_with_edges default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" lookup_pins default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+  done
+
+  for scenario in sedges_inline ledge_inline overflow; do
+    for nodes in $NODE_SIZES; do
+      run_one "$LIVEHD_BIN" "$LIVEHD_CSV" add_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      run_one "$LIVEHD_BIN" "$LIVEHD_CSV" delete_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      run_one "$LIVEHD_BIN" "$LIVEHD_CSV" lookup_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      run_one "$LIVEHD_BIN" "$LIVEHD_CSV" traverse_fast_class "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      run_one "$LIVEHD_BIN" "$LIVEHD_CSV" traverse_forward_class "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      # LiveHD currently declares backward(), but its implementation still
+      # contains a FIXME/assert. Leave backward LiveHD rows absent => N/A.
+    done
+  done
+
+  for nodes in $HIER_NODE_SIZES; do
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" traverse_fast_flat default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" traverse_forward_flat default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" traverse_fast_hier default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" traverse_forward_hier default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+  done
+
+  for hier in $HIER_SIZES; do
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" traverse_hier_range default hier "$HIER_RANGE_NODE_COUNT" 1 "$hier" 0
+  done
+else
+  echo "LiveHD benchmark source not found at $LIVEHD_ROOT; livehd/results.csv is header-only."
+fi
 
 "$PYTHON" "$BENCH_DIR/scripts/make_comparison.py" \
   --hhds "$HHDS_CSV" \
@@ -136,4 +185,3 @@ echo "Raw Boost CSV:     $BOOST_CSV"
 echo "Raw LiveHD CSV:    $LIVEHD_CSV"
 echo "Comparison CSV:    $COMPARISON_CSV"
 echo "Plots folder:      $PLOT_DIR"
-


### PR DESCRIPTION
## Summary

This PR updates the final benchmark reporting to use `ns/op` instead of total wall-clock time.

## Changes

- Convert comparison CSV values from total time to `wall_ns / items`
- Report the median `ns/op` across repeated runs
- Update plot y-axis labels to show `ns/op`
- Update benchmark README documentation to describe the new unit

## Why

`ns/op` is easier to compare across different graph sizes because it normalizes total runtime by the number of operations performed.

## Notes

Raw benchmark CSVs still keep `wall_ns` and `items`. The normalized `ns/op` values are generated in the comparison CSV and plots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark suite documentation clarifying directory layout, output definitions, and LiveHD setup requirements.
  * Added guidance for configuring LiveHD root path and conditional integration.

* **Improvements**
  * Benchmark timing metrics now calculated and displayed in nanoseconds per operation.
  * Plot generation dynamically reads and displays time unit labels from benchmark data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/masc-ucsc/hhds/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->