### PR TITLE
Tree diff tests

### DIFF
--- a/hhds/BUILD.bazel
+++ b/hhds/BUILD.bazel
@@ -462,6 +462,17 @@ cc_binary(
     ],
 )
 
+cc_test(
+    name = "hhds_tree_diff_test",
+    srcs = ["tests/hhds_tree_diff_test.cpp"],
+    size = "small",
+    deps = [
+        ":core",
+        ":tree_edit_distance",
+        "@googletest//:gtest_main",
+    ],
+)
+
 # cc_binary(
 #     name = "graph_bin",
 #     srcs = ["graph_main.cpp"],

--- a/hhds/hhds_tree_diff.cpp
+++ b/hhds/hhds_tree_diff.cpp
@@ -64,55 +64,72 @@ std::string extract_full_content(const std::string& line) {
 }
 
 struct DumpData {
+  DumpData() = default;
+  DumpData(DumpData&&) = default;
+  DumpData& operator=(DumpData&&) = default;
+  DumpData(const DumpData&) = delete;
+  DumpData& operator=(const DumpData&) = delete;
+  
   std::shared_ptr<hhds::Tree>                     tree;
   std::vector<hhds::Tree::NodeData>               nodes;
+  std::vector<std::string>                        type_names;
   std::vector<hhds::Type_entry>                   type_table;
   std::unordered_map<hhds::Tree_pos, std::string> node_texts;
   std::unordered_map<hhds::Tree_pos, std::string> full_labels;
 };
 
-std::vector<hhds::Type_entry> build_type_table(const std::string& filename) {
-  std::vector<std::string>                type_names;
-  std::unordered_map<std::string, size_t> type_idx;
+DumpData load_dump(const std::string& filename) {
+  DumpData data;
 
-  std::ifstream ifs(filename);
-  if (!ifs.is_open()) {
-    std::cerr << "hhds_tree_diff: cannot open " << filename << "\n";
-    return {};
-  }
-
-  std::string line;
-  bool        first_line = true;
-  while (std::getline(ifs, line)) {
-    if (first_line) {
-      first_line = false;
-      continue;
-    }
-    auto name = extract_type_name(line);
-    if (name.empty()) {
-      continue;
-    }
-    if (type_idx.find(name) == type_idx.end()) {
-      type_idx[name] = type_names.size();
-      type_names.push_back(std::move(name));
-    }
-  }
-
-  std::vector<hhds::Type_entry> table;
-  table.reserve(type_names.size());
-  for (const auto& n : type_names) {
-    table.push_back({n, hhds::Statement_class::Node});
-  }
-  return table;
-}
-
-std::unordered_map<hhds::Tree_pos, std::string> build_full_labels(const std::string&                       filename,
-                                                                  const std::vector<hhds::Tree::NodeData>& nodes) {
-  std::vector<std::string> contents;
   {
-    std::ifstream ifs(filename);
+    std::unordered_map<std::string, size_t> type_idx;
+    std::ifstream                           ifs(filename);
     if (!ifs.is_open()) {
-      return {};
+      std::cerr << "hhds_tree_diff: cannot open " << filename << "\n";
+      return data;
+    }
+    std::string line;
+    bool        first_line = true;
+    while (std::getline(ifs, line)) {
+      if (first_line) {
+        first_line = false;
+        continue;
+      }
+      auto name = extract_type_name(line);
+      if (name.empty()) {
+        continue;
+      }
+      if (type_idx.find(name) == type_idx.end()) {
+        type_idx[name] = data.type_names.size();
+        data.type_names.push_back(std::move(name));
+      }
+    }
+  }
+
+  data.type_table.reserve(data.type_names.size());
+  for (const auto& n : data.type_names) {
+    data.type_table.push_back({n, hhds::Statement_class::Node});
+  }
+
+  auto [tree, nodes] = hhds::Tree::read_dump(filename, data.type_table);
+  if (!tree) {
+    std::cerr << "hhds_tree_diff: failed to parse " << filename << "\n";
+    return data;
+  }
+  data.tree  = std::move(tree);
+  data.nodes = std::move(nodes);
+
+  for (const auto& nd : data.nodes) {
+    data.node_texts[nd.pos] = nd.node_text;
+  }
+
+  {
+    std::vector<std::string> contents;
+    std::ifstream            ifs(filename);
+    if (!ifs.is_open()) {
+      std::cerr << "hhds_tree_diff: cannot reopen " << filename << " for label extraction\n";
+      data.tree.reset();
+      return data;
     }
     std::string line;
     bool        first_line = true;
@@ -126,42 +143,57 @@ std::unordered_map<hhds::Tree_pos, std::string> build_full_labels(const std::str
         contents.push_back(std::move(c));
       }
     }
+    for (size_t i = 0; i < data.nodes.size() && i < contents.size(); ++i) {
+      data.full_labels[data.nodes[i].pos] = contents[i];
+    }
+    if (contents.size() != data.nodes.size()) {
+      std::cerr << "hhds_tree_diff: label count mismatch in " << filename
+                << " (expected " << data.nodes.size() << ", got " << contents.size() << ")\n";
+      data.tree.reset();
+      return data;
+    }
   }
-
-  std::unordered_map<hhds::Tree_pos, std::string> labels;
-  for (size_t i = 0; i < nodes.size() && i < contents.size(); ++i) {
-    labels[nodes[i].pos] = contents[i];
-  }
-  return labels;
-}
-
-DumpData load_dump(const std::string& filename) {
-  DumpData data;
-  data.type_table = build_type_table(filename);
-  if (data.type_table.empty()) {
-    return data;
-  }
-
-  auto [tree, nodes] = hhds::Tree::read_dump(filename, data.type_table);
-  data.tree          = std::move(tree);
-  data.nodes         = std::move(nodes);
-
-  for (const auto& nd : data.nodes) {
-    data.node_texts[nd.pos] = nd.node_text;
-  }
-
-  data.full_labels = build_full_labels(filename, data.nodes);
 
   return data;
 }
 
 void print_tree(const DumpData& data, const std::string& filename) {
+  std::unordered_map<hhds::Tree_pos, std::vector<std::pair<std::string, std::string>>> node_attrs;
+  std::vector<std::string>                                                             attr_keys;
+  std::unordered_map<std::string, bool>                                                seen_keys;
+  for (const auto& nd : data.nodes) {
+    if (!nd.attributes.empty()) {
+      node_attrs[nd.pos] = nd.attributes;
+      for (const auto& [k, _] : nd.attributes) {
+        if (!seen_keys[k]) {
+          seen_keys[k] = true;
+          attr_keys.push_back(k);
+        }
+      }
+    }
+  }
+
   hhds::Tree::PrintOptions opts;
   opts.type_table = data.type_table;
   opts.node_text  = [&data](const hhds::Tree::Node_class& node) {
     auto it = data.node_texts.find(node.get_debug_nid());
     return it == data.node_texts.end() ? std::string() : it->second;
   };
+  for (const auto& key : attr_keys) {
+    opts.attributes.emplace_back(key, [&node_attrs, key](const hhds::Tree::Node_class& node) -> std::optional<std::string> {
+      auto it = node_attrs.find(node.get_debug_nid());
+      if (it == node_attrs.end()) {
+        return std::nullopt;
+      }
+      for (const auto& [k, v] : it->second) {
+        if (k == key) {
+          return v;
+        }
+      }
+      return std::nullopt;
+    });
+  }
+
   std::cout << "=== " << filename << " ===\n";
   data.tree->dump(std::cout, opts);
   std::cout << "\n";

--- a/hhds/tests/hhds_tree_diff_test.cpp
+++ b/hhds/tests/hhds_tree_diff_test.cpp
@@ -1,0 +1,351 @@
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "tree.hpp"
+#include "tree_edit_distance.hpp"
+
+namespace {
+
+std::string write_temp_dump(const std::string& name, const std::string& content) {
+  std::string tmpl = "/tmp/hhds_test_" + name + "_XXXXXX";
+  int fd = mkstemp(tmpl.data());
+  EXPECT_NE(fd, -1) << "Cannot create temp file: " << tmpl;
+  if (fd == -1) return {};
+  close(fd);
+  std::ofstream ofs(tmpl);
+  EXPECT_TRUE(ofs.is_open()) << "Cannot open temp file: " << tmpl;
+  if (!ofs.is_open()) return {};
+  ofs << content;
+  return tmpl;
+}
+
+size_t find_content_start(const std::string& line) {
+  size_t       pos = 0;
+  const size_t len = line.size();
+  while (pos < len) {
+    if (pos + 9 < len && static_cast<unsigned char>(line[pos]) == 0xe2) {
+      const auto b1 = static_cast<unsigned char>(line[pos + 1]);
+      const auto b2 = static_cast<unsigned char>(line[pos + 2]);
+      if ((b1 == 0x94 && b2 == 0x9c) || (b1 == 0x94 && b2 == 0x94)) {
+        return pos + 10;
+      }
+    }
+    if (pos + 5 < len && static_cast<unsigned char>(line[pos]) == 0xe2 && static_cast<unsigned char>(line[pos + 1]) == 0x94
+        && static_cast<unsigned char>(line[pos + 2]) == 0x82) {
+      pos += 6;
+      continue;
+    }
+    if (pos + 3 < len && line[pos] == ' ' && line[pos + 1] == ' ' && line[pos + 2] == ' ' && line[pos + 3] == ' ') {
+      pos += 4;
+      continue;
+    }
+    break;
+  }
+  return std::string::npos;
+}
+
+std::string extract_type_name(const std::string& line) {
+  const size_t s = find_content_start(line);
+  if (s == std::string::npos) return {};
+  size_t e = s;
+  while (e < line.size() && line[e] != ' ' && line[e] != '\n' && line[e] != '\r') ++e;
+  return line.substr(s, e - s);
+}
+
+std::string extract_full_content(const std::string& line) {
+  const size_t s = find_content_start(line);
+  if (s == std::string::npos) return {};
+  size_t e = line.size();
+  while (e > s && (line[e - 1] == '\n' || line[e - 1] == '\r' || line[e - 1] == ' ')) --e;
+  return line.substr(s, e - s);
+}
+
+struct TestDumpData {
+  std::shared_ptr<hhds::Tree>                     tree;
+  std::vector<hhds::Tree::NodeData>                nodes;
+  std::vector<std::string>                         type_names;
+  std::vector<hhds::Type_entry>                    type_table;
+  std::unordered_map<hhds::Tree_pos, std::string>  full_labels;
+};
+
+TestDumpData load_test_dump(const std::string& filename) {
+  TestDumpData data;
+
+  {
+    std::unordered_map<std::string, size_t> type_idx;
+    std::ifstream ifs(filename);
+    if (!ifs.is_open()) return data;
+    std::string line;
+    bool first_line = true;
+    while (std::getline(ifs, line)) {
+      if (first_line) { first_line = false; continue; }
+      auto name = extract_type_name(line);
+      if (name.empty()) continue;
+      if (type_idx.find(name) == type_idx.end()) {
+        type_idx[name] = data.type_names.size();
+        data.type_names.push_back(std::move(name));
+      }
+    }
+  }
+
+  data.type_table.reserve(data.type_names.size());
+  for (const auto& n : data.type_names) {
+    data.type_table.push_back({n, hhds::Statement_class::Node});
+  }
+
+  auto [tree, nodes] = hhds::Tree::read_dump(filename, data.type_table);
+  data.tree  = std::move(tree);
+  data.nodes = std::move(nodes);
+
+  {
+    std::vector<std::string> contents;
+    std::ifstream ifs(filename);
+    if (!ifs.is_open()) return data;
+    std::string line;
+    bool first_line = true;
+    while (std::getline(ifs, line)) {
+      if (first_line) { first_line = false; continue; }
+      auto c = extract_full_content(line);
+      if (!c.empty()) contents.push_back(std::move(c));
+    }
+    for (size_t i = 0; i < data.nodes.size() && i < contents.size(); ++i) {
+      data.full_labels[data.nodes[i].pos] = contents[i];
+    }
+  }
+
+  return data;
+}
+
+double compute_diff(const TestDumpData& d1, const TestDumpData& d2) {
+  auto cost_fn = [&d1, &d2](const hhds::Tree::Node_class& a, const hhds::Tree::Node_class& b) -> double {
+    std::string la, lb;
+    auto it1 = d1.full_labels.find(a.get_debug_nid());
+    if (it1 != d1.full_labels.end()) la = it1->second;
+    auto it2 = d2.full_labels.find(b.get_debug_nid());
+    if (it2 != d2.full_labels.end()) lb = it2->second;
+    return (la == lb) ? 0.0 : 1.0;
+  };
+  auto result = hhds::TreeEditDistance::compute(d1.tree, d2.tree, hhds::EditCosts{}, cost_fn);
+  return result.distance;
+}
+
+
+const std::string add_trivial_dump =
+    "add_trivial\n"
+    "└── top\n"
+    "    └── stmts\n"
+    "        ├── attr_set\n"
+    "        │   ├── ref 'x'\n"
+    "        │   ├── const 'type'\n"
+    "        │   └── const\n"
+    "        ├── assign\n"
+    "        │   ├── ref 'x'\n"
+    "        │   └── const '1'\n"
+    "        ├── attr_set\n"
+    "        │   ├── ref 'y'\n"
+    "        │   ├── const 'type'\n"
+    "        │   └── const\n"
+    "        ├── assign\n"
+    "        │   ├── ref 'y'\n"
+    "        │   └── const '2'\n"
+    "        ├── plus\n"
+    "        │   ├── ref '___1'\n"
+    "        │   ├── ref 'x'\n"
+    "        │   └── ref 'y'\n"
+    "        ├── attr_set\n"
+    "        │   ├── ref 'c'\n"
+    "        │   ├── const 'type'\n"
+    "        │   └── const 'mut'\n"
+    "        ├── assign\n"
+    "        │   ├── ref 'c'\n"
+    "        │   └── ref '___1'\n"
+    "        ├── eq\n"
+    "        │   ├── ref '___2'\n"
+    "        │   ├── ref 'c'\n"
+    "        │   └── const '3'\n"
+    "        └── cassert\n"
+    "            └── ref '___2'\n";
+
+const std::string add_trivial_swapped_dump =
+    "add_trivial_swapped\n"
+    "└── top\n"
+    "    └── stmts\n"
+    "        ├── attr_set\n"
+    "        │   ├── ref 'y'\n"
+    "        │   ├── const 'type'\n"
+    "        │   └── const\n"
+    "        ├── assign\n"
+    "        │   ├── ref 'y'\n"
+    "        │   └── const '2'\n"
+    "        ├── attr_set\n"
+    "        │   ├── ref 'x'\n"
+    "        │   ├── const 'type'\n"
+    "        │   └── const\n"
+    "        ├── assign\n"
+    "        │   ├── ref 'x'\n"
+    "        │   └── const '1'\n"
+    "        ├── plus\n"
+    "        │   ├── ref '___1'\n"
+    "        │   ├── ref 'x'\n"
+    "        │   └── ref 'y'\n"
+    "        ├── attr_set\n"
+    "        │   ├── ref 'c'\n"
+    "        │   ├── const 'type'\n"
+    "        │   └── const 'mut'\n"
+    "        ├── assign\n"
+    "        │   ├── ref 'c'\n"
+    "        │   └── ref '___1'\n"
+    "        ├── eq\n"
+    "        │   ├── ref '___2'\n"
+    "        │   ├── ref 'c'\n"
+    "        │   └── const '3'\n"
+    "        └── cassert\n"
+    "            └── ref '___2'\n";
+
+const std::string simple_tree_dump =
+    "simple\n"
+    "└── top\n"
+    "    ├── assign\n"
+    "    │   ├── ref 'a'\n"
+    "    │   └── const '1'\n"
+    "    └── assign\n"
+    "        ├── ref 'b'\n"
+    "        └── const '2'\n";
+
+const std::string simple_tree_extra_node_dump =
+    "simple_extra\n"
+    "└── top\n"
+    "    ├── assign\n"
+    "    │   ├── ref 'a'\n"
+    "    │   └── const '1'\n"
+    "    ├── assign\n"
+    "    │   ├── ref 'b'\n"
+    "    │   └── const '2'\n"
+    "    └── assign\n"
+    "        ├── ref 'c'\n"
+    "        └── const '3'\n";
+
+}  // namespace
+
+// ─── Test cases ──────────────────────────────────────────────────────
+
+TEST(TreeDiff, IdenticalTrees) {
+  auto path1 = write_temp_dump("identical_a", add_trivial_dump);
+  auto path2 = write_temp_dump("identical_b", add_trivial_dump);
+
+  auto d1 = load_test_dump(path1);
+  auto d2 = load_test_dump(path2);
+
+  ASSERT_NE(d1.tree, nullptr);
+  ASSERT_NE(d2.tree, nullptr);
+
+  double dist = compute_diff(d1, d2);
+  EXPECT_EQ(dist, 0.0) << "Identical dumps should have distance 0";
+
+  std::remove(path1.c_str());
+  std::remove(path2.c_str());
+}
+
+TEST(TreeDiff, SwappedDeclarations) {
+  auto path1 = write_temp_dump("swap_a", add_trivial_dump);
+  auto path2 = write_temp_dump("swap_b", add_trivial_swapped_dump);
+
+  auto d1 = load_test_dump(path1);
+  auto d2 = load_test_dump(path2);
+
+  ASSERT_NE(d1.tree, nullptr);
+  ASSERT_NE(d2.tree, nullptr);
+
+  double dist = compute_diff(d1, d2);
+  EXPECT_EQ(dist, 6.0) << "Swapping x/y declarations should give distance 6";
+
+  std::remove(path1.c_str());
+  std::remove(path2.c_str());
+}
+
+TEST(TreeDiff, SingleInsertion) {
+  auto path1 = write_temp_dump("insert_a", simple_tree_dump);
+  auto path2 = write_temp_dump("insert_b", simple_tree_extra_node_dump);
+
+  auto d1 = load_test_dump(path1);
+  auto d2 = load_test_dump(path2);
+
+  ASSERT_NE(d1.tree, nullptr);
+  ASSERT_NE(d2.tree, nullptr);
+
+  double dist = compute_diff(d1, d2);
+  // Inserting one assign subtree (assign + ref 'c' + const '3') = 3 insertions
+  EXPECT_EQ(dist, 3.0) << "Inserting one assign subtree should cost 3";
+
+  std::remove(path1.c_str());
+  std::remove(path2.c_str());
+}
+
+TEST(TreeDiff, SymmetricDistance) {
+  auto path1 = write_temp_dump("sym_a", add_trivial_dump);
+  auto path2 = write_temp_dump("sym_b", add_trivial_swapped_dump);
+
+  auto d1 = load_test_dump(path1);
+  auto d2 = load_test_dump(path2);
+
+  ASSERT_NE(d1.tree, nullptr);
+  ASSERT_NE(d2.tree, nullptr);
+
+  double dist_ab = compute_diff(d1, d2);
+  double dist_ba = compute_diff(d2, d1);
+  EXPECT_EQ(dist_ab, dist_ba) << "TED should be symmetric";
+
+  std::remove(path1.c_str());
+  std::remove(path2.c_str());
+}
+
+TEST(TreeDiff, SelfDistance) {
+  auto path = write_temp_dump("self", simple_tree_dump);
+
+  auto d = load_test_dump(path);
+  ASSERT_NE(d.tree, nullptr);
+
+  double dist = compute_diff(d, d);
+  EXPECT_EQ(dist, 0.0) << "Distance to self should be 0";
+
+  std::remove(path.c_str());
+}
+
+TEST(TreeDiff, MissingFile) {
+  std::string tmpl = "/tmp/hhds_test_missing_XXXXXX";
+  int fd = mkstemp(tmpl.data());
+  ASSERT_NE(fd, -1);
+  close(fd);
+  std::remove(tmpl.c_str());
+  auto d = load_test_dump(tmpl);
+  EXPECT_EQ(d.tree, nullptr) << "Loading missing file should return null tree";
+}
+
+TEST(TreeDiff, TypeTableCorrectness) {
+  auto path = write_temp_dump("types", add_trivial_dump);
+  auto d = load_test_dump(path);
+
+  std::vector<std::string> expected_types = {"top", "stmts", "attr_set", "ref", "const", "assign", "plus", "eq", "cassert"};
+  ASSERT_EQ(d.type_names.size(), expected_types.size());
+  for (size_t i = 0; i < expected_types.size(); ++i) {
+    EXPECT_EQ(d.type_names[i], expected_types[i]) << "Type at index " << i << " mismatch";
+  }
+
+  std::remove(path.c_str());
+}
+
+TEST(TreeDiff, NodeCount) {
+  auto path = write_temp_dump("count", add_trivial_dump);
+  auto d = load_test_dump(path);
+
+  ASSERT_NE(d.tree, nullptr);
+  // add_trivial has 33 nodes: top, stmts, 3*attr_set + 9 children,
+  // 3*assign + 6 children, plus + 3 children, eq + 3 children, cassert + 1 child
+  EXPECT_EQ(d.nodes.size(), 33U) << "add_trivial should have 33 nodes";
+
+  std::remove(path.c_str());
+}


### PR DESCRIPTION
Note: merge after this PR: [Fix type display in hhds_tree_diff](https://github.com/masc-ucsc/hhds/pull/217)
## Summary

Adds a googletest-based test suite for `hhds_tree_diff`, verifying dump file loading, type table construction, and tree edit distance computation on LNAST-style dump files.

## Files Added

* `hhds/tests/hhds_tree_diff_test.cpp` — test suite with 8 test cases
* `hhds/BUILD.bazel` — added `cc_test` target for `hhds_tree_diff_test`

## Test Cases

| Test | What it verifies |
|------|-----------------|
| `IdenticalTrees` | Same dump file → distance 0 |
| `SwappedDeclarations` | Swapping `const x`/`const y` order → distance 6 |
| `SingleInsertion` | Adding one assign subtree → distance 3 |
| `SymmetricDistance` | dist(A,B) == dist(B,A) |
| `SelfDistance` | dist(A,A) == 0 |
| `MissingFile` | Nonexistent file → null tree |
| `TypeTableCorrectness` | Type names extracted in expected order |
| `NodeCount` | `add_trivial` dump produces exactly 33 nodes |

## Test Output

```
bazel test //hhds:hhds_tree_diff_test
//hhds:hhds_tree_diff_test    PASSED in 0.1s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive test suite validating tree edit-distance across multiple scenarios (identical dumps, swapped declarations, subtree insertion, symmetry, self-distance, missing input, and type-table/node-count checks).
  * Tests use temporary dump files and clean up after execution.

* **Refactor**
  * Consolidated dump-loading and label extraction into a single, more robust load flow.
  * Extended tree printing to include node attributes alongside existing output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/masc-ucsc/hhds/pull/218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->