### PR TITLE
Semantic diff tests

### DIFF
--- a/hhds/BUILD.bazel
+++ b/hhds/BUILD.bazel
@@ -462,6 +462,17 @@ cc_binary(
     ],
 )
 
+cc_test(
+    name = "hhds_tree_diff_test",
+    srcs = ["tests/hhds_tree_diff_test.cpp"],
+    size = "small",
+    deps = [
+        ":core",
+        ":tree_edit_distance",
+        "@googletest//:gtest_main",
+    ],
+)
+
 # cc_binary(
 #     name = "graph_bin",
 #     srcs = ["graph_main.cpp"],

--- a/hhds/BUILD.bazel
+++ b/hhds/BUILD.bazel
@@ -473,6 +473,18 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "semantic_diff_test",
+    size = "small",
+    srcs = ["tests/semantic_diff_test.cpp"],
+    data = [":hhds_tree_diff"],
+    deps = [
+        ":core",
+        ":tree_edit_distance",
+        "@googletest//:gtest_main",
+    ],
+)
+
 # cc_binary(
 #     name = "graph_bin",
 #     srcs = ["graph_main.cpp"],

--- a/hhds/hhds_tree_diff.cpp
+++ b/hhds/hhds_tree_diff.cpp
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <unistd.h>
 
 #include "tree.hpp"
 #include "tree_edit_distance.hpp"
@@ -61,6 +62,230 @@ std::string extract_full_content(const std::string& line) {
     --e;
   }
   return line.substr(s, e - s);
+}
+
+// ─── Semantic canonicalization helpers ────────────────────────────────
+// These functions reorder independent statement groups under `stmts`
+// so that semantically equivalent programs produce identical trees.
+
+int compute_depth(const std::string& line) {
+  int    depth = 0;
+  size_t pos   = 0;
+  const size_t len = line.size();
+  while (pos < len) {
+    if (pos + 5 < len && static_cast<unsigned char>(line[pos]) == 0xe2
+        && static_cast<unsigned char>(line[pos + 1]) == 0x94
+        && static_cast<unsigned char>(line[pos + 2]) == 0x82) {
+      ++depth;
+      pos += 6;
+      continue;
+    }
+    if (pos + 3 < len && line[pos] == ' ' && line[pos + 1] == ' '
+        && line[pos + 2] == ' ' && line[pos + 3] == ' ') {
+      ++depth;
+      pos += 4;
+      continue;
+    }
+    break;
+  }
+  return depth;
+}
+
+std::string extract_ref_name(const std::string& content) {
+  auto pos = content.find('\'');
+  if (pos == std::string::npos) return {};
+  auto end = content.find('\'', pos + 1);
+  if (end == std::string::npos) return {};
+  return content.substr(pos + 1, end - pos - 1);
+}
+
+struct StmtGroup {
+  std::vector<int>       line_indices;
+  std::string            write_var;
+  std::set<std::string>  read_vars;
+  std::string            sort_key;
+};
+
+
+void extract_refs(const std::vector<std::string>& lines, const std::vector<int>& indices,
+                  std::string& write_var, std::set<std::string>& read_vars) {
+  bool first_ref = true;
+  for (int idx : indices) {
+    auto type = extract_type_name(lines[idx]);
+    if (type == "ref") {
+      auto name = extract_ref_name(extract_full_content(lines[idx]));
+      if (name.empty()) continue;
+      if (first_ref) {
+        write_var = name;
+        first_ref = false;
+      } else if (name != write_var) {
+        read_vars.insert(name);
+      }
+    }
+  }
+}
+
+std::string canonicalize_dump(const std::string& filename) {
+  std::ifstream ifs(filename);
+  if (!ifs.is_open()) return filename;
+  std::vector<std::string> lines;
+  std::string line;
+  while (std::getline(ifs, line)) {
+    lines.push_back(line);
+  }
+  ifs.close();
+
+  int stmts_idx   = -1;
+  int stmts_depth = -1;
+  for (int i = 1; i < static_cast<int>(lines.size()); ++i) {
+    if (extract_type_name(lines[i]) == "stmts") {
+      stmts_idx   = i;
+      stmts_depth = compute_depth(lines[i]);
+      break;
+    }
+  }
+  if (stmts_idx < 0) return filename;
+
+  int child_depth = stmts_depth + 1;
+
+  struct Subtree { int start; int end; };
+  std::vector<Subtree> subtrees;
+
+  for (int i = stmts_idx + 1; i < static_cast<int>(lines.size()); ++i) {
+    int d = compute_depth(lines[i]);
+    if (d < child_depth) break;
+    if (d == child_depth) {
+      if (!subtrees.empty()) subtrees.back().end = i;
+      subtrees.push_back({i, static_cast<int>(lines.size())});
+    }
+  }
+  if (!subtrees.empty()) {
+    for (int i = subtrees.back().start + 1; i < static_cast<int>(lines.size()); ++i) {
+      if (compute_depth(lines[i]) <= stmts_depth) {
+        subtrees.back().end = i;
+        break;
+      }
+    }
+  }
+  if (subtrees.empty()) return filename;
+
+  std::vector<StmtGroup> groups;
+  int si = 0;
+  while (si < static_cast<int>(subtrees.size())) {
+    auto type_si = extract_type_name(lines[subtrees[si].start]);
+
+    std::vector<int> indices_si;
+    for (int li = subtrees[si].start; li < subtrees[si].end; ++li) {
+      indices_si.push_back(li);
+    }
+
+    std::string ref_si;
+    for (int li = subtrees[si].start + 1; li < subtrees[si].end; ++li) {
+      if (extract_type_name(lines[li]) == "ref") {
+        ref_si = extract_ref_name(extract_full_content(lines[li]));
+        break;
+      }
+    }
+
+    if (type_si == "attr_set" && si + 1 < static_cast<int>(subtrees.size())) {
+      auto type_next = extract_type_name(lines[subtrees[si + 1].start]);
+      std::string ref_next;
+      for (int li = subtrees[si + 1].start + 1; li < subtrees[si + 1].end; ++li) {
+        if (extract_type_name(lines[li]) == "ref") {
+          ref_next = extract_ref_name(extract_full_content(lines[li]));
+          break;
+        }
+      }
+
+      if (type_next == "assign" && ref_si == ref_next) {
+        StmtGroup g;
+        for (int li = subtrees[si].start; li < subtrees[si].end; ++li)
+          g.line_indices.push_back(li);
+        for (int li = subtrees[si + 1].start; li < subtrees[si + 1].end; ++li)
+          g.line_indices.push_back(li);
+
+        extract_refs(lines, g.line_indices, g.write_var, g.read_vars);
+        g.sort_key = g.write_var.empty() ? ref_si : g.write_var;
+        groups.push_back(std::move(g));
+        si += 2;
+        continue;
+      }
+    }
+
+    StmtGroup g;
+    g.line_indices = std::move(indices_si);
+    extract_refs(lines, g.line_indices, g.write_var, g.read_vars);
+    g.sort_key = g.write_var.empty() ? ref_si : g.write_var;
+    groups.push_back(std::move(g));
+    ++si;
+  }
+
+  int ng = static_cast<int>(groups.size());
+  std::vector<std::vector<int>> adj(ng);
+  std::vector<int>              in_degree(ng, 0);
+
+  for (int a = 0; a < ng; ++a) {
+    for (int b = a + 1; b < ng; ++b) {
+      bool dep = false;
+      if (!groups[a].write_var.empty() && groups[b].read_vars.count(groups[a].write_var)) dep = true;
+      if (!groups[b].write_var.empty() && groups[a].read_vars.count(groups[b].write_var)) dep = true;
+      if (!groups[a].write_var.empty() && groups[a].write_var == groups[b].write_var) dep = true;
+
+      if (dep) {
+        adj[a].push_back(b);
+        ++in_degree[b];
+      }
+    }
+  }
+
+  auto cmp = [&groups](int a, int b) {
+    if (groups[a].sort_key != groups[b].sort_key)
+      return groups[a].sort_key < groups[b].sort_key;
+    return a < b;
+  };
+  std::set<int, decltype(cmp)> ready(cmp);
+  for (int i = 0; i < ng; ++i) {
+    if (in_degree[i] == 0) ready.insert(i);
+  }
+
+  std::vector<int> sorted_order;
+  sorted_order.reserve(ng);
+  while (!ready.empty()) {
+    int u = *ready.begin();
+    ready.erase(ready.begin());
+    sorted_order.push_back(u);
+    for (int v : adj[u]) {
+      if (--in_degree[v] == 0) ready.insert(v);
+    }
+  }
+
+  std::string result;
+  for (int i = 0; i <= stmts_idx; ++i) {
+    result += lines[i];
+    result += '\n';
+  }
+  for (int gi : sorted_order) {
+    for (int li : groups[gi].line_indices) {
+      result += lines[li];
+      result += '\n';
+    }
+  }
+  int after_stmts = subtrees.back().end;
+  for (int i = after_stmts; i < static_cast<int>(lines.size()); ++i) {
+    result += lines[i];
+    result += '\n';
+  }
+
+  std::string tmpl = "/tmp/hhds_semantic_XXXXXX";
+  int fd = mkstemp(tmpl.data());
+  if (fd == -1) return filename;
+  close(fd);
+  std::ofstream ofs(tmpl);
+  if (!ofs.is_open()) return filename;
+  ofs << result;
+  ofs.close();
+
+  return tmpl;
 }
 
 struct DumpData {
@@ -202,21 +427,29 @@ void print_tree(const DumpData& data, const std::string& filename) {
 }  // namespace
 
 int main(int argc, char** argv) {
-  if (argc != 3) {
-    std::cerr << "Usage: " << argv[0] << " <dump_file_1> <dump_file_2>\n";
+  if (argc < 3 || argc > 4) {
+    std::cerr << "Usage: " << argv[0] << " <dump_file_1> <dump_file_2> [--semantic]\n";
     return 1;
   }
 
   const std::string file1 = argv[1];
   const std::string file2 = argv[2];
+  const bool semantic = (argc == 4 && std::string(argv[3]) == "--semantic");
 
-  auto data1 = load_dump(file1);
+  std::string load_file1 = file1;
+  std::string load_file2 = file2;
+  if (semantic) {
+    load_file1 = canonicalize_dump(file1);
+    load_file2 = canonicalize_dump(file2);
+  }
+
+  auto data1 = load_dump(load_file1);
   if (!data1.tree) {
     std::cerr << "hhds_tree_diff: failed to parse " << file1 << "\n";
     return 1;
   }
 
-  auto data2 = load_dump(file2);
+  auto data2 = load_dump(load_file2);
   if (!data2.tree) {
     std::cerr << "hhds_tree_diff: failed to parse " << file2 << "\n";
     return 1;
@@ -244,7 +477,15 @@ int main(int argc, char** argv) {
   auto result = hhds::TreeEditDistance::compute(data1.tree, data2.tree, hhds::EditCosts{}, cost_fn);
 
   std::cout << "=== Tree Edit Distance ===\n";
+  if (semantic) {
+    std::cout << "Mode: semantic (independent statements canonicalized)\n";
+  }
   std::cout << "Distance: " << result.distance << "\n";
+
+  if (semantic) {
+    if (load_file1 != file1) std::remove(load_file1.c_str());
+    if (load_file2 != file2) std::remove(load_file2.c_str());
+  }
 
   return 0;
 }

--- a/hhds/hhds_tree_diff.cpp
+++ b/hhds/hhds_tree_diff.cpp
@@ -64,55 +64,72 @@ std::string extract_full_content(const std::string& line) {
 }
 
 struct DumpData {
+  DumpData() = default;
+  DumpData(DumpData&&) = default;
+  DumpData& operator=(DumpData&&) = default;
+  DumpData(const DumpData&) = delete;
+  DumpData& operator=(const DumpData&) = delete;
+  
   std::shared_ptr<hhds::Tree>                     tree;
   std::vector<hhds::Tree::NodeData>               nodes;
+  std::vector<std::string>                        type_names;
   std::vector<hhds::Type_entry>                   type_table;
   std::unordered_map<hhds::Tree_pos, std::string> node_texts;
   std::unordered_map<hhds::Tree_pos, std::string> full_labels;
 };
 
-std::vector<hhds::Type_entry> build_type_table(const std::string& filename) {
-  std::vector<std::string>                type_names;
-  std::unordered_map<std::string, size_t> type_idx;
+DumpData load_dump(const std::string& filename) {
+  DumpData data;
 
-  std::ifstream ifs(filename);
-  if (!ifs.is_open()) {
-    std::cerr << "hhds_tree_diff: cannot open " << filename << "\n";
-    return {};
-  }
-
-  std::string line;
-  bool        first_line = true;
-  while (std::getline(ifs, line)) {
-    if (first_line) {
-      first_line = false;
-      continue;
-    }
-    auto name = extract_type_name(line);
-    if (name.empty()) {
-      continue;
-    }
-    if (type_idx.find(name) == type_idx.end()) {
-      type_idx[name] = type_names.size();
-      type_names.push_back(std::move(name));
-    }
-  }
-
-  std::vector<hhds::Type_entry> table;
-  table.reserve(type_names.size());
-  for (const auto& n : type_names) {
-    table.push_back({n, hhds::Statement_class::Node});
-  }
-  return table;
-}
-
-std::unordered_map<hhds::Tree_pos, std::string> build_full_labels(const std::string&                       filename,
-                                                                  const std::vector<hhds::Tree::NodeData>& nodes) {
-  std::vector<std::string> contents;
   {
-    std::ifstream ifs(filename);
+    std::unordered_map<std::string, size_t> type_idx;
+    std::ifstream                           ifs(filename);
     if (!ifs.is_open()) {
-      return {};
+      std::cerr << "hhds_tree_diff: cannot open " << filename << "\n";
+      return data;
+    }
+    std::string line;
+    bool        first_line = true;
+    while (std::getline(ifs, line)) {
+      if (first_line) {
+        first_line = false;
+        continue;
+      }
+      auto name = extract_type_name(line);
+      if (name.empty()) {
+        continue;
+      }
+      if (type_idx.find(name) == type_idx.end()) {
+        type_idx[name] = data.type_names.size();
+        data.type_names.push_back(std::move(name));
+      }
+    }
+  }
+
+  data.type_table.reserve(data.type_names.size());
+  for (const auto& n : data.type_names) {
+    data.type_table.push_back({n, hhds::Statement_class::Node});
+  }
+
+  auto [tree, nodes] = hhds::Tree::read_dump(filename, data.type_table);
+  if (!tree) {
+    std::cerr << "hhds_tree_diff: failed to parse " << filename << "\n";
+    return data;
+  }
+  data.tree  = std::move(tree);
+  data.nodes = std::move(nodes);
+
+  for (const auto& nd : data.nodes) {
+    data.node_texts[nd.pos] = nd.node_text;
+  }
+
+  {
+    std::vector<std::string> contents;
+    std::ifstream            ifs(filename);
+    if (!ifs.is_open()) {
+      std::cerr << "hhds_tree_diff: cannot reopen " << filename << " for label extraction\n";
+      data.tree.reset();
+      return data;
     }
     std::string line;
     bool        first_line = true;
@@ -126,42 +143,57 @@ std::unordered_map<hhds::Tree_pos, std::string> build_full_labels(const std::str
         contents.push_back(std::move(c));
       }
     }
+    for (size_t i = 0; i < data.nodes.size() && i < contents.size(); ++i) {
+      data.full_labels[data.nodes[i].pos] = contents[i];
+    }
+    if (contents.size() != data.nodes.size()) {
+      std::cerr << "hhds_tree_diff: label count mismatch in " << filename
+                << " (expected " << data.nodes.size() << ", got " << contents.size() << ")\n";
+      data.tree.reset();
+      return data;
+    }
   }
-
-  std::unordered_map<hhds::Tree_pos, std::string> labels;
-  for (size_t i = 0; i < nodes.size() && i < contents.size(); ++i) {
-    labels[nodes[i].pos] = contents[i];
-  }
-  return labels;
-}
-
-DumpData load_dump(const std::string& filename) {
-  DumpData data;
-  data.type_table = build_type_table(filename);
-  if (data.type_table.empty()) {
-    return data;
-  }
-
-  auto [tree, nodes] = hhds::Tree::read_dump(filename, data.type_table);
-  data.tree          = std::move(tree);
-  data.nodes         = std::move(nodes);
-
-  for (const auto& nd : data.nodes) {
-    data.node_texts[nd.pos] = nd.node_text;
-  }
-
-  data.full_labels = build_full_labels(filename, data.nodes);
 
   return data;
 }
 
 void print_tree(const DumpData& data, const std::string& filename) {
+  std::unordered_map<hhds::Tree_pos, std::vector<std::pair<std::string, std::string>>> node_attrs;
+  std::vector<std::string>                                                             attr_keys;
+  std::unordered_map<std::string, bool>                                                seen_keys;
+  for (const auto& nd : data.nodes) {
+    if (!nd.attributes.empty()) {
+      node_attrs[nd.pos] = nd.attributes;
+      for (const auto& [k, _] : nd.attributes) {
+        if (!seen_keys[k]) {
+          seen_keys[k] = true;
+          attr_keys.push_back(k);
+        }
+      }
+    }
+  }
+
   hhds::Tree::PrintOptions opts;
   opts.type_table = data.type_table;
   opts.node_text  = [&data](const hhds::Tree::Node_class& node) {
     auto it = data.node_texts.find(node.get_debug_nid());
     return it == data.node_texts.end() ? std::string() : it->second;
   };
+  for (const auto& key : attr_keys) {
+    opts.attributes.emplace_back(key, [&node_attrs, key](const hhds::Tree::Node_class& node) -> std::optional<std::string> {
+      auto it = node_attrs.find(node.get_debug_nid());
+      if (it == node_attrs.end()) {
+        return std::nullopt;
+      }
+      for (const auto& [k, v] : it->second) {
+        if (k == key) {
+          return v;
+        }
+      }
+      return std::nullopt;
+    });
+  }
+
   std::cout << "=== " << filename << " ===\n";
   data.tree->dump(std::cout, opts);
   std::cout << "\n";

--- a/hhds/tests/hhds_tree_diff_test.cpp
+++ b/hhds/tests/hhds_tree_diff_test.cpp
@@ -1,0 +1,351 @@
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "tree.hpp"
+#include "tree_edit_distance.hpp"
+
+namespace {
+
+std::string write_temp_dump(const std::string& name, const std::string& content) {
+  std::string tmpl = "/tmp/hhds_test_" + name + "_XXXXXX";
+  int fd = mkstemp(tmpl.data());
+  EXPECT_NE(fd, -1) << "Cannot create temp file: " << tmpl;
+  if (fd == -1) return {};
+  close(fd);
+  std::ofstream ofs(tmpl);
+  EXPECT_TRUE(ofs.is_open()) << "Cannot open temp file: " << tmpl;
+  if (!ofs.is_open()) return {};
+  ofs << content;
+  return tmpl;
+}
+
+size_t find_content_start(const std::string& line) {
+  size_t       pos = 0;
+  const size_t len = line.size();
+  while (pos < len) {
+    if (pos + 9 < len && static_cast<unsigned char>(line[pos]) == 0xe2) {
+      const auto b1 = static_cast<unsigned char>(line[pos + 1]);
+      const auto b2 = static_cast<unsigned char>(line[pos + 2]);
+      if ((b1 == 0x94 && b2 == 0x9c) || (b1 == 0x94 && b2 == 0x94)) {
+        return pos + 10;
+      }
+    }
+    if (pos + 5 < len && static_cast<unsigned char>(line[pos]) == 0xe2 && static_cast<unsigned char>(line[pos + 1]) == 0x94
+        && static_cast<unsigned char>(line[pos + 2]) == 0x82) {
+      pos += 6;
+      continue;
+    }
+    if (pos + 3 < len && line[pos] == ' ' && line[pos + 1] == ' ' && line[pos + 2] == ' ' && line[pos + 3] == ' ') {
+      pos += 4;
+      continue;
+    }
+    break;
+  }
+  return std::string::npos;
+}
+
+std::string extract_type_name(const std::string& line) {
+  const size_t s = find_content_start(line);
+  if (s == std::string::npos) return {};
+  size_t e = s;
+  while (e < line.size() && line[e] != ' ' && line[e] != '\n' && line[e] != '\r') ++e;
+  return line.substr(s, e - s);
+}
+
+std::string extract_full_content(const std::string& line) {
+  const size_t s = find_content_start(line);
+  if (s == std::string::npos) return {};
+  size_t e = line.size();
+  while (e > s && (line[e - 1] == '\n' || line[e - 1] == '\r' || line[e - 1] == ' ')) --e;
+  return line.substr(s, e - s);
+}
+
+struct TestDumpData {
+  std::shared_ptr<hhds::Tree>                     tree;
+  std::vector<hhds::Tree::NodeData>                nodes;
+  std::vector<std::string>                         type_names;
+  std::vector<hhds::Type_entry>                    type_table;
+  std::unordered_map<hhds::Tree_pos, std::string>  full_labels;
+};
+
+TestDumpData load_test_dump(const std::string& filename) {
+  TestDumpData data;
+
+  {
+    std::unordered_map<std::string, size_t> type_idx;
+    std::ifstream ifs(filename);
+    if (!ifs.is_open()) return data;
+    std::string line;
+    bool first_line = true;
+    while (std::getline(ifs, line)) {
+      if (first_line) { first_line = false; continue; }
+      auto name = extract_type_name(line);
+      if (name.empty()) continue;
+      if (type_idx.find(name) == type_idx.end()) {
+        type_idx[name] = data.type_names.size();
+        data.type_names.push_back(std::move(name));
+      }
+    }
+  }
+
+  data.type_table.reserve(data.type_names.size());
+  for (const auto& n : data.type_names) {
+    data.type_table.push_back({n, hhds::Statement_class::Node});
+  }
+
+  auto [tree, nodes] = hhds::Tree::read_dump(filename, data.type_table);
+  data.tree  = std::move(tree);
+  data.nodes = std::move(nodes);
+
+  {
+    std::vector<std::string> contents;
+    std::ifstream ifs(filename);
+    if (!ifs.is_open()) return data;
+    std::string line;
+    bool first_line = true;
+    while (std::getline(ifs, line)) {
+      if (first_line) { first_line = false; continue; }
+      auto c = extract_full_content(line);
+      if (!c.empty()) contents.push_back(std::move(c));
+    }
+    for (size_t i = 0; i < data.nodes.size() && i < contents.size(); ++i) {
+      data.full_labels[data.nodes[i].pos] = contents[i];
+    }
+  }
+
+  return data;
+}
+
+double compute_diff(const TestDumpData& d1, const TestDumpData& d2) {
+  auto cost_fn = [&d1, &d2](const hhds::Tree::Node_class& a, const hhds::Tree::Node_class& b) -> double {
+    std::string la, lb;
+    auto it1 = d1.full_labels.find(a.get_debug_nid());
+    if (it1 != d1.full_labels.end()) la = it1->second;
+    auto it2 = d2.full_labels.find(b.get_debug_nid());
+    if (it2 != d2.full_labels.end()) lb = it2->second;
+    return (la == lb) ? 0.0 : 1.0;
+  };
+  auto result = hhds::TreeEditDistance::compute(d1.tree, d2.tree, hhds::EditCosts{}, cost_fn);
+  return result.distance;
+}
+
+
+const std::string add_trivial_dump =
+    "add_trivial\n"
+    "└── top\n"
+    "    └── stmts\n"
+    "        ├── attr_set\n"
+    "        │   ├── ref 'x'\n"
+    "        │   ├── const 'type'\n"
+    "        │   └── const\n"
+    "        ├── assign\n"
+    "        │   ├── ref 'x'\n"
+    "        │   └── const '1'\n"
+    "        ├── attr_set\n"
+    "        │   ├── ref 'y'\n"
+    "        │   ├── const 'type'\n"
+    "        │   └── const\n"
+    "        ├── assign\n"
+    "        │   ├── ref 'y'\n"
+    "        │   └── const '2'\n"
+    "        ├── plus\n"
+    "        │   ├── ref '___1'\n"
+    "        │   ├── ref 'x'\n"
+    "        │   └── ref 'y'\n"
+    "        ├── attr_set\n"
+    "        │   ├── ref 'c'\n"
+    "        │   ├── const 'type'\n"
+    "        │   └── const 'mut'\n"
+    "        ├── assign\n"
+    "        │   ├── ref 'c'\n"
+    "        │   └── ref '___1'\n"
+    "        ├── eq\n"
+    "        │   ├── ref '___2'\n"
+    "        │   ├── ref 'c'\n"
+    "        │   └── const '3'\n"
+    "        └── cassert\n"
+    "            └── ref '___2'\n";
+
+const std::string add_trivial_swapped_dump =
+    "add_trivial_swapped\n"
+    "└── top\n"
+    "    └── stmts\n"
+    "        ├── attr_set\n"
+    "        │   ├── ref 'y'\n"
+    "        │   ├── const 'type'\n"
+    "        │   └── const\n"
+    "        ├── assign\n"
+    "        │   ├── ref 'y'\n"
+    "        │   └── const '2'\n"
+    "        ├── attr_set\n"
+    "        │   ├── ref 'x'\n"
+    "        │   ├── const 'type'\n"
+    "        │   └── const\n"
+    "        ├── assign\n"
+    "        │   ├── ref 'x'\n"
+    "        │   └── const '1'\n"
+    "        ├── plus\n"
+    "        │   ├── ref '___1'\n"
+    "        │   ├── ref 'x'\n"
+    "        │   └── ref 'y'\n"
+    "        ├── attr_set\n"
+    "        │   ├── ref 'c'\n"
+    "        │   ├── const 'type'\n"
+    "        │   └── const 'mut'\n"
+    "        ├── assign\n"
+    "        │   ├── ref 'c'\n"
+    "        │   └── ref '___1'\n"
+    "        ├── eq\n"
+    "        │   ├── ref '___2'\n"
+    "        │   ├── ref 'c'\n"
+    "        │   └── const '3'\n"
+    "        └── cassert\n"
+    "            └── ref '___2'\n";
+
+const std::string simple_tree_dump =
+    "simple\n"
+    "└── top\n"
+    "    ├── assign\n"
+    "    │   ├── ref 'a'\n"
+    "    │   └── const '1'\n"
+    "    └── assign\n"
+    "        ├── ref 'b'\n"
+    "        └── const '2'\n";
+
+const std::string simple_tree_extra_node_dump =
+    "simple_extra\n"
+    "└── top\n"
+    "    ├── assign\n"
+    "    │   ├── ref 'a'\n"
+    "    │   └── const '1'\n"
+    "    ├── assign\n"
+    "    │   ├── ref 'b'\n"
+    "    │   └── const '2'\n"
+    "    └── assign\n"
+    "        ├── ref 'c'\n"
+    "        └── const '3'\n";
+
+}  // namespace
+
+// ─── Test cases ──────────────────────────────────────────────────────
+
+TEST(TreeDiff, IdenticalTrees) {
+  auto path1 = write_temp_dump("identical_a", add_trivial_dump);
+  auto path2 = write_temp_dump("identical_b", add_trivial_dump);
+
+  auto d1 = load_test_dump(path1);
+  auto d2 = load_test_dump(path2);
+
+  ASSERT_NE(d1.tree, nullptr);
+  ASSERT_NE(d2.tree, nullptr);
+
+  double dist = compute_diff(d1, d2);
+  EXPECT_EQ(dist, 0.0) << "Identical dumps should have distance 0";
+
+  std::remove(path1.c_str());
+  std::remove(path2.c_str());
+}
+
+TEST(TreeDiff, SwappedDeclarations) {
+  auto path1 = write_temp_dump("swap_a", add_trivial_dump);
+  auto path2 = write_temp_dump("swap_b", add_trivial_swapped_dump);
+
+  auto d1 = load_test_dump(path1);
+  auto d2 = load_test_dump(path2);
+
+  ASSERT_NE(d1.tree, nullptr);
+  ASSERT_NE(d2.tree, nullptr);
+
+  double dist = compute_diff(d1, d2);
+  EXPECT_EQ(dist, 6.0) << "Swapping x/y declarations should give distance 6";
+
+  std::remove(path1.c_str());
+  std::remove(path2.c_str());
+}
+
+TEST(TreeDiff, SingleInsertion) {
+  auto path1 = write_temp_dump("insert_a", simple_tree_dump);
+  auto path2 = write_temp_dump("insert_b", simple_tree_extra_node_dump);
+
+  auto d1 = load_test_dump(path1);
+  auto d2 = load_test_dump(path2);
+
+  ASSERT_NE(d1.tree, nullptr);
+  ASSERT_NE(d2.tree, nullptr);
+
+  double dist = compute_diff(d1, d2);
+  // Inserting one assign subtree (assign + ref 'c' + const '3') = 3 insertions
+  EXPECT_EQ(dist, 3.0) << "Inserting one assign subtree should cost 3";
+
+  std::remove(path1.c_str());
+  std::remove(path2.c_str());
+}
+
+TEST(TreeDiff, SymmetricDistance) {
+  auto path1 = write_temp_dump("sym_a", add_trivial_dump);
+  auto path2 = write_temp_dump("sym_b", add_trivial_swapped_dump);
+
+  auto d1 = load_test_dump(path1);
+  auto d2 = load_test_dump(path2);
+
+  ASSERT_NE(d1.tree, nullptr);
+  ASSERT_NE(d2.tree, nullptr);
+
+  double dist_ab = compute_diff(d1, d2);
+  double dist_ba = compute_diff(d2, d1);
+  EXPECT_EQ(dist_ab, dist_ba) << "TED should be symmetric";
+
+  std::remove(path1.c_str());
+  std::remove(path2.c_str());
+}
+
+TEST(TreeDiff, SelfDistance) {
+  auto path = write_temp_dump("self", simple_tree_dump);
+
+  auto d = load_test_dump(path);
+  ASSERT_NE(d.tree, nullptr);
+
+  double dist = compute_diff(d, d);
+  EXPECT_EQ(dist, 0.0) << "Distance to self should be 0";
+
+  std::remove(path.c_str());
+}
+
+TEST(TreeDiff, MissingFile) {
+  std::string tmpl = "/tmp/hhds_test_missing_XXXXXX";
+  int fd = mkstemp(tmpl.data());
+  ASSERT_NE(fd, -1);
+  close(fd);
+  std::remove(tmpl.c_str());
+  auto d = load_test_dump(tmpl);
+  EXPECT_EQ(d.tree, nullptr) << "Loading missing file should return null tree";
+}
+
+TEST(TreeDiff, TypeTableCorrectness) {
+  auto path = write_temp_dump("types", add_trivial_dump);
+  auto d = load_test_dump(path);
+
+  std::vector<std::string> expected_types = {"top", "stmts", "attr_set", "ref", "const", "assign", "plus", "eq", "cassert"};
+  ASSERT_EQ(d.type_names.size(), expected_types.size());
+  for (size_t i = 0; i < expected_types.size(); ++i) {
+    EXPECT_EQ(d.type_names[i], expected_types[i]) << "Type at index " << i << " mismatch";
+  }
+
+  std::remove(path.c_str());
+}
+
+TEST(TreeDiff, NodeCount) {
+  auto path = write_temp_dump("count", add_trivial_dump);
+  auto d = load_test_dump(path);
+
+  ASSERT_NE(d.tree, nullptr);
+  // add_trivial has 33 nodes: top, stmts, 3*attr_set + 9 children,
+  // 3*assign + 6 children, plus + 3 children, eq + 3 children, cassert + 1 child
+  EXPECT_EQ(d.nodes.size(), 33U) << "add_trivial should have 33 nodes";
+
+  std::remove(path.c_str());
+}

--- a/hhds/tests/semantic_diff_test.cpp
+++ b/hhds/tests/semantic_diff_test.cpp
@@ -1,0 +1,578 @@
+// This file is distributed under the BSD 3-Clause License. See LICENSE for details.
+//
+// Tests for semantic diff canonicalization in hhds_tree_diff.
+// Verifies dependency analysis, statement grouping, and canonical reordering.
+
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "tree.hpp"
+#include "tree_edit_distance.hpp"
+
+namespace {
+
+std::string write_temp(const std::string& name, const std::string& content) {
+  std::string tmpl = "/tmp/hhds_semtest_" + name + "_XXXXXX";
+  int         fd   = mkstemp(tmpl.data());
+  EXPECT_NE(fd, -1) << "Cannot create temp file: " << tmpl;
+  if (fd == -1) {
+    return {};
+  }
+  close(fd);
+  std::ofstream ofs(tmpl);
+  EXPECT_TRUE(ofs.is_open()) << "Cannot open temp file: " << tmpl;
+  if (!ofs.is_open()) {
+    return {};
+  }
+  ofs << content;
+  return tmpl;
+}
+
+size_t find_content_start(const std::string& line) {
+  size_t       pos = 0;
+  const size_t len = line.size();
+  while (pos < len) {
+    if (pos + 9 < len && static_cast<unsigned char>(line[pos]) == 0xe2) {
+      const auto b1 = static_cast<unsigned char>(line[pos + 1]);
+      const auto b2 = static_cast<unsigned char>(line[pos + 2]);
+      if ((b1 == 0x94 && b2 == 0x9c) || (b1 == 0x94 && b2 == 0x94)) {
+        return pos + 10;
+      }
+    }
+    if (pos + 5 < len && static_cast<unsigned char>(line[pos]) == 0xe2 && static_cast<unsigned char>(line[pos + 1]) == 0x94
+        && static_cast<unsigned char>(line[pos + 2]) == 0x82) {
+      pos += 6;
+      continue;
+    }
+    if (pos + 3 < len && line[pos] == ' ' && line[pos + 1] == ' ' && line[pos + 2] == ' ' && line[pos + 3] == ' ') {
+      pos += 4;
+      continue;
+    }
+    break;
+  }
+  return std::string::npos;
+}
+
+std::string extract_type_name(const std::string& line) {
+  const size_t s = find_content_start(line);
+  if (s == std::string::npos) {
+    return {};
+  }
+  size_t e = s;
+  while (e < line.size() && line[e] != ' ' && line[e] != '\n' && line[e] != '\r') {
+    ++e;
+  }
+  return line.substr(s, e - s);
+}
+
+std::string extract_full_content(const std::string& line) {
+  const size_t s = find_content_start(line);
+  if (s == std::string::npos) {
+    return {};
+  }
+  size_t e = line.size();
+  while (e > s && (line[e - 1] == '\n' || line[e - 1] == '\r' || line[e - 1] == ' ')) {
+    --e;
+  }
+  return line.substr(s, e - s);
+}
+
+struct TestDumpData {
+  std::shared_ptr<hhds::Tree>                     tree;
+  std::vector<hhds::Tree::NodeData>               nodes;
+  std::vector<std::string>                        type_names;
+  std::vector<hhds::Type_entry>                   type_table;
+  std::unordered_map<hhds::Tree_pos, std::string> full_labels;
+};
+
+TestDumpData load_test_dump(const std::string& filename) {
+  TestDumpData data;
+  {
+    std::unordered_map<std::string, size_t> type_idx;
+    std::ifstream                           ifs(filename);
+    if (!ifs.is_open()) {
+      return data;
+    }
+    std::string line;
+    bool        first_line = true;
+    while (std::getline(ifs, line)) {
+      if (first_line) {
+        first_line = false;
+        continue;
+      }
+      auto name = extract_type_name(line);
+      if (name.empty()) {
+        continue;
+      }
+      if (type_idx.find(name) == type_idx.end()) {
+        type_idx[name] = data.type_names.size();
+        data.type_names.push_back(std::move(name));
+      }
+    }
+  }
+  data.type_table.reserve(data.type_names.size());
+  for (const auto& n : data.type_names) {
+    data.type_table.push_back({n, hhds::Statement_class::Node});
+  }
+
+  auto [tree, nodes] = hhds::Tree::read_dump(filename, data.type_table);
+  data.tree          = std::move(tree);
+  data.nodes         = std::move(nodes);
+
+  {
+    std::vector<std::string> contents;
+    std::ifstream            ifs(filename);
+    if (!ifs.is_open()) {
+      return data;
+    }
+    std::string line;
+    bool        first_line = true;
+    while (std::getline(ifs, line)) {
+      if (first_line) {
+        first_line = false;
+        continue;
+      }
+      auto c = extract_full_content(line);
+      if (!c.empty()) {
+        contents.push_back(std::move(c));
+      }
+    }
+    for (size_t i = 0; i < data.nodes.size() && i < contents.size(); ++i) {
+      data.full_labels[data.nodes[i].pos] = contents[i];
+    }
+  }
+  return data;
+}
+
+double compute_diff(const TestDumpData& d1, const TestDumpData& d2) {
+  auto cost_fn = [&d1, &d2](const hhds::Tree::Node_class& a, const hhds::Tree::Node_class& b) -> double {
+    std::string la, lb;
+    auto        it1 = d1.full_labels.find(a.get_debug_nid());
+    if (it1 != d1.full_labels.end()) {
+      la = it1->second;
+    }
+    auto it2 = d2.full_labels.find(b.get_debug_nid());
+    if (it2 != d2.full_labels.end()) {
+      lb = it2->second;
+    }
+    return (la == lb) ? 0.0 : 1.0;
+  };
+  return hhds::TreeEditDistance::compute(d1.tree, d2.tree, hhds::EditCosts{}, cost_fn).distance;
+}
+
+double run_diff(const std::string& file1, const std::string& file2, bool semantic = false) {
+  std::string binary    = "hhds/hhds_tree_diff";
+  const char* srcdir    = std::getenv("TEST_SRCDIR");
+  const char* workspace = std::getenv("TEST_WORKSPACE");
+  if (srcdir && workspace) {
+    binary = std::string(srcdir) + "/" + std::string(workspace) + "/" + binary;
+  }
+  std::string cmd = binary + " " + file1 + " " + file2;
+  if (semantic) {
+    cmd += " --semantic";
+  }
+  cmd += " 2>/dev/null";
+
+  FILE* pipe = popen(cmd.c_str(), "r");
+  if (!pipe) {
+    return -1;
+  }
+
+  double distance = -1;
+  char   buf[256];
+  while (fgets(buf, sizeof(buf), pipe)) {
+    std::string line(buf);
+    auto        pos = line.find("Distance: ");
+    if (pos != std::string::npos) {
+      distance = std::stod(line.substr(pos + 10));
+    }
+  }
+  pclose(pipe);
+  return distance;
+}
+
+// Original: const x = 1; const y = 2; mut c = x + y; cassert c == 3
+const std::string add_trivial
+    = "add_trivial\n"
+      "└── top\n"
+      "    └── stmts\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'x'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        ├── assign\n"
+      "        │   ├── ref 'x'\n"
+      "        │   └── const '1'\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'y'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        ├── assign\n"
+      "        │   ├── ref 'y'\n"
+      "        │   └── const '2'\n"
+      "        ├── plus\n"
+      "        │   ├── ref '___1'\n"
+      "        │   ├── ref 'x'\n"
+      "        │   └── ref 'y'\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'c'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const 'mut'\n"
+      "        ├── assign\n"
+      "        │   ├── ref 'c'\n"
+      "        │   └── ref '___1'\n"
+      "        ├── eq\n"
+      "        │   ├── ref '___2'\n"
+      "        │   ├── ref 'c'\n"
+      "        │   └── const '3'\n"
+      "        └── cassert\n"
+      "            └── ref '___2'\n";
+
+// Swapped: const y = 2; const x = 1; mut c = x + y; cassert c == 3
+const std::string add_trivial_swapped
+    = "add_trivial_swapped\n"
+      "└── top\n"
+      "    └── stmts\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'y'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        ├── assign\n"
+      "        │   ├── ref 'y'\n"
+      "        │   └── const '2'\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'x'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        ├── assign\n"
+      "        │   ├── ref 'x'\n"
+      "        │   └── const '1'\n"
+      "        ├── plus\n"
+      "        │   ├── ref '___1'\n"
+      "        │   ├── ref 'x'\n"
+      "        │   └── ref 'y'\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'c'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const 'mut'\n"
+      "        ├── assign\n"
+      "        │   ├── ref 'c'\n"
+      "        │   └── ref '___1'\n"
+      "        ├── eq\n"
+      "        │   ├── ref '___2'\n"
+      "        │   ├── ref 'c'\n"
+      "        │   └── const '3'\n"
+      "        └── cassert\n"
+      "            └── ref '___2'\n";
+
+// Three independent declarations: a=1, b=2, c=3 (no dependencies between them)
+const std::string three_independent
+    = "three_ind\n"
+      "└── top\n"
+      "    └── stmts\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'a'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        ├── assign\n"
+      "        │   ├── ref 'a'\n"
+      "        │   └── const '1'\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'b'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        ├── assign\n"
+      "        │   ├── ref 'b'\n"
+      "        │   └── const '2'\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'c'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        └── assign\n"
+      "            ├── ref 'c'\n"
+      "            └── const '3'\n";
+
+// Same three declarations in reverse order: c=3, b=2, a=1
+const std::string three_independent_reversed
+    = "three_rev\n"
+      "└── top\n"
+      "    └── stmts\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'c'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        ├── assign\n"
+      "        │   ├── ref 'c'\n"
+      "        │   └── const '3'\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'b'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        ├── assign\n"
+      "        │   ├── ref 'b'\n"
+      "        │   └── const '2'\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'a'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        └── assign\n"
+      "            ├── ref 'a'\n"
+      "            └── const '1'\n";
+
+// Dependent: a=1, b=a+1 (b depends on a, cannot reorder)
+const std::string dependent_raw
+    = "dep_raw\n"
+      "└── top\n"
+      "    └── stmts\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'a'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        ├── assign\n"
+      "        │   ├── ref 'a'\n"
+      "        │   └── const '1'\n"
+      "        ├── plus\n"
+      "        │   ├── ref '___1'\n"
+      "        │   ├── ref 'a'\n"
+      "        │   └── const '1'\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'b'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        └── assign\n"
+      "            ├── ref 'b'\n"
+      "            └── ref '___1'\n";
+
+// Same as above but INCORRECTLY reordered: b=a+1, a=1
+// Semantic diff should NOT make these equal (b depends on a)
+const std::string dependent_raw_swapped
+    = "dep_raw_swap\n"
+      "└── top\n"
+      "    └── stmts\n"
+      "        ├── plus\n"
+      "        │   ├── ref '___1'\n"
+      "        │   ├── ref 'a'\n"
+      "        │   └── const '1'\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'b'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        ├── assign\n"
+      "        │   ├── ref 'b'\n"
+      "        │   └── ref '___1'\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'a'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        └── assign\n"
+      "            ├── ref 'a'\n"
+      "            └── const '1'\n";
+
+// Single statement: just a = 1
+const std::string single_stmt
+    = "single\n"
+      "└── top\n"
+      "    └── stmts\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'a'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        └── assign\n"
+      "            ├── ref 'a'\n"
+      "            └── const '1'\n";
+
+// a=100, b=100
+const std::string ab_hundred
+    = "ab_hundred\n"
+      "└── top\n"
+      "    └── stmts\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'a'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        ├── assign\n"
+      "        │   ├── ref 'a'\n"
+      "        │   └── const '100'\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'b'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        └── assign\n"
+      "            ├── ref 'b'\n"
+      "            └── const '100'\n";
+
+// b=100, a=100 (swapped version)
+const std::string ba_hundred
+    = "ba_hundred\n"
+      "└── top\n"
+      "    └── stmts\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'b'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        ├── assign\n"
+      "        │   ├── ref 'b'\n"
+      "        │   └── const '100'\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'a'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        └── assign\n"
+      "            ├── ref 'a'\n"
+      "            └── const '100'\n";
+
+// Actually different values: a=1 vs a=2
+const std::string a_is_one
+    = "a_one\n"
+      "└── top\n"
+      "    └── stmts\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'a'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        └── assign\n"
+      "            ├── ref 'a'\n"
+      "            └── const '1'\n";
+
+const std::string a_is_two
+    = "a_two\n"
+      "└── top\n"
+      "    └── stmts\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'a'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        └── assign\n"
+      "            ├── ref 'a'\n"
+      "            └── const '2'\n";
+
+}  // namespace
+
+// ─── Test cases ──────────────────────────────────────────────────────
+
+class SemanticDiffTest : public ::testing::Test {
+protected:
+  std::vector<std::string> temp_files;
+
+  std::string make_temp(const std::string& name, const std::string& content) {
+    auto path = write_temp(name, content);
+    if (!path.empty()) {
+      temp_files.push_back(path);
+    }
+    return path;
+  }
+
+  void TearDown() override {
+    for (const auto& f : temp_files) {
+      std::remove(f.c_str());
+    }
+  }
+};
+
+// ── Plain diff baseline tests ────────────────────────────────────────
+
+TEST_F(SemanticDiffTest, PlainDiff_IdenticalTrees) {
+  auto f1 = make_temp("plain_id_a", add_trivial);
+  auto f2 = make_temp("plain_id_b", add_trivial);
+  auto d1 = load_test_dump(f1);
+  auto d2 = load_test_dump(f2);
+  EXPECT_EQ(compute_diff(d1, d2), 0.0);
+}
+
+TEST_F(SemanticDiffTest, PlainDiff_SwappedDeclarations) {
+  auto f1 = make_temp("plain_sw_a", add_trivial);
+  auto f2 = make_temp("plain_sw_b", add_trivial_swapped);
+  auto d1 = load_test_dump(f1);
+  auto d2 = load_test_dump(f2);
+  EXPECT_EQ(compute_diff(d1, d2), 6.0) << "Plain diff should detect 6 relabels for swapped x/y declarations";
+}
+
+// ── Semantic diff: independent statement reordering ──────────────────
+
+TEST_F(SemanticDiffTest, Semantic_SwappedDeclarations_DistanceZero) {
+  auto   f1   = make_temp("sem_sw_a", add_trivial);
+  auto   f2   = make_temp("sem_sw_b", add_trivial_swapped);
+  double dist = run_diff(f1, f2, /*semantic=*/true);
+  EXPECT_EQ(dist, 0.0) << "Semantic diff: swapping independent const x/y should give distance 0";
+}
+
+TEST_F(SemanticDiffTest, Semantic_ThreeIndependent_Reversed) {
+  auto   f1   = make_temp("sem_3i_a", three_independent);
+  auto   f2   = make_temp("sem_3i_b", three_independent_reversed);
+  double dist = run_diff(f1, f2, /*semantic=*/true);
+  EXPECT_EQ(dist, 0.0) << "Semantic diff: reversing 3 independent declarations should give distance 0";
+}
+
+TEST_F(SemanticDiffTest, Semantic_ProfessorExample_AB_Hundred) {
+  auto   f1   = make_temp("sem_ab_a", ab_hundred);
+  auto   f2   = make_temp("sem_ab_b", ba_hundred);
+  double dist = run_diff(f1, f2, /*semantic=*/true);
+  EXPECT_EQ(dist, 0.0) << "Semantic diff: a=100;b=100 ≡ b=100;a=100 should give distance 0";
+}
+
+// ── Semantic diff: dependency preservation ───────────────────────────
+
+TEST_F(SemanticDiffTest, Semantic_DependentStatements_NotReordered) {
+  auto   f1   = make_temp("sem_dep_a", dependent_raw);
+  auto   f2   = make_temp("sem_dep_b", dependent_raw_swapped);
+  double dist = run_diff(f1, f2, /*semantic=*/true);
+  EXPECT_GT(dist, 0.0) << "Semantic diff: dependent statements (b=a+1 depends on a=1) should NOT be equivalent when reordered";
+}
+
+// ── Semantic diff: no false equivalence ──────────────────────────────
+
+TEST_F(SemanticDiffTest, Semantic_DifferentValues_NotEquivalent) {
+  auto   f1   = make_temp("sem_val_a", a_is_one);
+  auto   f2   = make_temp("sem_val_b", a_is_two);
+  double dist = run_diff(f1, f2, /*semantic=*/true);
+  EXPECT_GT(dist, 0.0) << "Semantic diff: a=1 vs a=2 are genuinely different, distance must be > 0";
+}
+
+TEST_F(SemanticDiffTest, Semantic_IdenticalTrees_StillZero) {
+  auto   f1   = make_temp("sem_id_a", add_trivial);
+  auto   f2   = make_temp("sem_id_b", add_trivial);
+  double dist = run_diff(f1, f2, /*semantic=*/true);
+  EXPECT_EQ(dist, 0.0) << "Semantic diff: identical trees should still be distance 0";
+}
+
+// ── Semantic diff: single statement edge case ────────────────────────
+
+TEST_F(SemanticDiffTest, Semantic_SingleStatement_SelfCompare) {
+  auto   f1   = make_temp("sem_single_a", single_stmt);
+  auto   f2   = make_temp("sem_single_b", single_stmt);
+  double dist = run_diff(f1, f2, /*semantic=*/true);
+  EXPECT_EQ(dist, 0.0) << "Semantic diff: single statement compared to itself should be 0";
+}
+
+// ── Semantic diff: plain mode unaffected ─────────────────────────────
+
+TEST_F(SemanticDiffTest, PlainMode_AB_Hundred_NotZero) {
+  auto   f1   = make_temp("plain_ab_a", ab_hundred);
+  auto   f2   = make_temp("plain_ab_b", ba_hundred);
+  double dist = run_diff(f1, f2, /*semantic=*/false);
+  EXPECT_GT(dist, 0.0) << "Plain diff: a=100;b=100 vs b=100;a=100 should detect differences";
+}
+
+TEST_F(SemanticDiffTest, PlainMode_ThreeIndependent_NotZero) {
+  auto   f1   = make_temp("plain_3i_a", three_independent);
+  auto   f2   = make_temp("plain_3i_b", three_independent_reversed);
+  double dist = run_diff(f1, f2, /*semantic=*/false);
+  EXPECT_GT(dist, 0.0) << "Plain diff: reversed independent declarations should detect differences";
+}
+
+// ── Symmetry ─────────────────────────────────────────────────────────
+
+TEST_F(SemanticDiffTest, Semantic_Symmetry) {
+  auto   f1      = make_temp("sym_a", add_trivial);
+  auto   f2      = make_temp("sym_b", add_trivial_swapped);
+  double dist_ab = run_diff(f1, f2, /*semantic=*/true);
+  double dist_ba = run_diff(f2, f1, /*semantic=*/true);
+  EXPECT_EQ(dist_ab, dist_ba) << "Semantic diff should be symmetric";
+}


### PR DESCRIPTION
Note: merge after this PR: [Add Semantic diff for tree comparisons](https://github.com/masc-ucsc/hhds/pull/219)
## Summary

Adds a comprehensive test suite for the semantic diff mode in `hhds_tree_diff`, verifying dependency analysis, statement grouping, canonical reordering, and correctness of both plain and semantic modes.

## Files Added

* `hhds/tests/semantic_diff_test.cpp` — 12 test cases
* `hhds/BUILD.bazel` — added `cc_test` target for `semantic_diff_test`

## Test Cases

| Category | Test | Expectation |
|----------|------|-------------|
| Plain baseline | `PlainDiff_IdenticalTrees` | distance 0 |
| Plain baseline | `PlainDiff_SwappedDeclarations` | distance 6 |
| Independent reordering | `Semantic_SwappedDeclarations_DistanceZero` | distance 0 |
| Independent reordering | `Semantic_ThreeIndependent_Reversed` | distance 0 |
| Independent reordering | `Semantic_ProfessorExample_AB_Hundred` | distance 0 |
| Dependency preservation | `Semantic_DependentStatements_NotReordered` | distance > 0 |
| No false equivalence | `Semantic_DifferentValues_NotEquivalent` | distance > 0 |
| No false equivalence | `Semantic_IdenticalTrees_StillZero` | distance 0 |
| Edge case | `Semantic_SingleStatement_SelfCompare` | distance 0 |
| Plain mode unaffected | `PlainMode_AB_Hundred_NotZero` | distance > 0 |
| Plain mode unaffected | `PlainMode_ThreeIndependent_NotZero` | distance > 0 |
| Symmetry | `Semantic_Symmetry` | dist(A,B) == dist(B,A) |

## Test Output

```
bazel test //hhds:semantic_diff_test
//hhds:semantic_diff_test    PASSED in 0.1s
```