### PR TITLE
Commutative ops tests

### DIFF
--- a/hhds/BUILD.bazel
+++ b/hhds/BUILD.bazel
@@ -495,6 +495,16 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "commutative_ops_test",
+    size = "small",
+    srcs = ["tests/commutative_ops_test.cpp"],
+    data = [":hhds_tree_diff"],
+    deps = [
+        "@googletest//:gtest_main",
+    ],
+)
+
 # cc_binary(
 #     name = "graph_bin",
 #     srcs = ["graph_main.cpp"],

--- a/hhds/hhds_tree_diff.cpp
+++ b/hhds/hhds_tree_diff.cpp
@@ -1,3 +1,6 @@
+#include <unistd.h>
+
+#include <algorithm>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -6,7 +9,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#include <unistd.h>
 
 #include "tree.hpp"
 #include "tree_edit_distance.hpp"
@@ -69,19 +71,17 @@ std::string extract_full_content(const std::string& line) {
 // so that semantically equivalent programs produce identical trees.
 
 int compute_depth(const std::string& line) {
-  int    depth = 0;
-  size_t pos   = 0;
-  const size_t len = line.size();
+  int          depth = 0;
+  size_t       pos   = 0;
+  const size_t len   = line.size();
   while (pos < len) {
-    if (pos + 5 < len && static_cast<unsigned char>(line[pos]) == 0xe2
-        && static_cast<unsigned char>(line[pos + 1]) == 0x94
+    if (pos + 5 < len && static_cast<unsigned char>(line[pos]) == 0xe2 && static_cast<unsigned char>(line[pos + 1]) == 0x94
         && static_cast<unsigned char>(line[pos + 2]) == 0x82) {
       ++depth;
       pos += 6;
       continue;
     }
-    if (pos + 3 < len && line[pos] == ' ' && line[pos + 1] == ' '
-        && line[pos + 2] == ' ' && line[pos + 3] == ' ') {
+    if (pos + 3 < len && line[pos] == ' ' && line[pos + 1] == ' ' && line[pos + 2] == ' ' && line[pos + 3] == ' ') {
       ++depth;
       pos += 4;
       continue;
@@ -93,28 +93,33 @@ int compute_depth(const std::string& line) {
 
 std::string extract_ref_name(const std::string& content) {
   auto pos = content.find('\'');
-  if (pos == std::string::npos) return {};
+  if (pos == std::string::npos) {
+    return {};
+  }
   auto end = content.find('\'', pos + 1);
-  if (end == std::string::npos) return {};
+  if (end == std::string::npos) {
+    return {};
+  }
   return content.substr(pos + 1, end - pos - 1);
 }
 
 struct StmtGroup {
-  std::vector<int>       line_indices;
-  std::string            write_var;
-  std::set<std::string>  read_vars;
-  std::string            sort_key;
+  std::vector<int>      line_indices;
+  std::string           write_var;
+  std::set<std::string> read_vars;
+  std::string           sort_key;
 };
 
-
-void extract_refs(const std::vector<std::string>& lines, const std::vector<int>& indices,
-                  std::string& write_var, std::set<std::string>& read_vars) {
+void extract_refs(const std::vector<std::string>& lines, const std::vector<int>& indices, std::string& write_var,
+                  std::set<std::string>& read_vars) {
   bool first_ref = true;
   for (int idx : indices) {
     auto type = extract_type_name(lines[idx]);
     if (type == "ref") {
       auto name = extract_ref_name(extract_full_content(lines[idx]));
-      if (name.empty()) continue;
+      if (name.empty()) {
+        continue;
+      }
       if (first_ref) {
         write_var = name;
         first_ref = false;
@@ -125,11 +130,84 @@ void extract_refs(const std::vector<std::string>& lines, const std::vector<int>&
   }
 }
 
+bool is_commutative(const std::string& type_name) {
+  return type_name == "plus" || type_name == "mult" || type_name == "bit_and" || type_name == "bit_or" || type_name == "bit_xor"
+         || type_name == "log_and" || type_name == "log_or" || type_name == "eq" || type_name == "ne";
+}
+
+void canonicalize_commutative(std::vector<std::string>& lines) {
+  for (int i = 0; i < static_cast<int>(lines.size()); ++i) {
+    auto type = extract_type_name(lines[i]);
+    if (!is_commutative(type)) {
+      continue;
+    }
+
+    int parent_depth = compute_depth(lines[i]);
+    int child_depth  = parent_depth + 1;
+
+    // Find children subtrees
+    struct Subtree {
+      int start;
+      int end;
+    };
+    std::vector<Subtree> children;
+    for (int j = i + 1; j < static_cast<int>(lines.size()); ++j) {
+      int d = compute_depth(lines[j]);
+      if (d < child_depth) {
+        break;
+      }
+      if (d == child_depth) {
+        if (!children.empty()) {
+          children.back().end = j;
+        }
+        children.push_back({j, static_cast<int>(lines.size())});
+      }
+    }
+    if (!children.empty()) {
+      for (int j = children.back().start + 1; j < static_cast<int>(lines.size()); ++j) {
+        if (compute_depth(lines[j]) <= parent_depth) {
+          children.back().end = j;
+          break;
+        }
+      }
+    }
+
+    if (children.size() < 3) {
+      continue;
+    }
+
+    struct OperandData {
+      std::vector<std::string> subtree_lines;
+      std::string              sort_key;
+    };
+    std::vector<OperandData> operands;
+    for (size_t c = 1; c < children.size(); ++c) {
+      OperandData op;
+      for (int li = children[c].start; li < children[c].end; ++li) {
+        op.subtree_lines.push_back(lines[li]);
+      }
+      op.sort_key = extract_full_content(lines[children[c].start]);
+      operands.push_back(std::move(op));
+    }
+
+    std::sort(operands.begin(), operands.end(), [](const OperandData& a, const OperandData& b) { return a.sort_key < b.sort_key; });
+
+    int write_pos = children[1].start;
+    for (const auto& op : operands) {
+      for (const auto& ol : op.subtree_lines) {
+        lines[write_pos++] = ol;
+      }
+    }
+  }
+}
+
 std::string canonicalize_dump(const std::string& filename) {
   std::ifstream ifs(filename);
-  if (!ifs.is_open()) return filename;
+  if (!ifs.is_open()) {
+    return filename;
+  }
   std::vector<std::string> lines;
-  std::string line;
+  std::string              line;
   while (std::getline(ifs, line)) {
     lines.push_back(line);
   }
@@ -144,18 +222,27 @@ std::string canonicalize_dump(const std::string& filename) {
       break;
     }
   }
-  if (stmts_idx < 0) return filename;
+  if (stmts_idx < 0) {
+    return filename;
+  }
 
   int child_depth = stmts_depth + 1;
 
-  struct Subtree { int start; int end; };
+  struct Subtree {
+    int start;
+    int end;
+  };
   std::vector<Subtree> subtrees;
 
   for (int i = stmts_idx + 1; i < static_cast<int>(lines.size()); ++i) {
     int d = compute_depth(lines[i]);
-    if (d < child_depth) break;
+    if (d < child_depth) {
+      break;
+    }
     if (d == child_depth) {
-      if (!subtrees.empty()) subtrees.back().end = i;
+      if (!subtrees.empty()) {
+        subtrees.back().end = i;
+      }
       subtrees.push_back({i, static_cast<int>(lines.size())});
     }
   }
@@ -167,10 +254,12 @@ std::string canonicalize_dump(const std::string& filename) {
       }
     }
   }
-  if (subtrees.empty()) return filename;
+  if (subtrees.empty()) {
+    return filename;
+  }
 
   std::vector<StmtGroup> groups;
-  int si = 0;
+  int                    si = 0;
   while (si < static_cast<int>(subtrees.size())) {
     auto type_si = extract_type_name(lines[subtrees[si].start]);
 
@@ -188,7 +277,7 @@ std::string canonicalize_dump(const std::string& filename) {
     }
 
     if (type_si == "attr_set" && si + 1 < static_cast<int>(subtrees.size())) {
-      auto type_next = extract_type_name(lines[subtrees[si + 1].start]);
+      auto        type_next = extract_type_name(lines[subtrees[si + 1].start]);
       std::string ref_next;
       for (int li = subtrees[si + 1].start + 1; li < subtrees[si + 1].end; ++li) {
         if (extract_type_name(lines[li]) == "ref") {
@@ -199,10 +288,12 @@ std::string canonicalize_dump(const std::string& filename) {
 
       if (type_next == "assign" && ref_si == ref_next) {
         StmtGroup g;
-        for (int li = subtrees[si].start; li < subtrees[si].end; ++li)
+        for (int li = subtrees[si].start; li < subtrees[si].end; ++li) {
           g.line_indices.push_back(li);
-        for (int li = subtrees[si + 1].start; li < subtrees[si + 1].end; ++li)
+        }
+        for (int li = subtrees[si + 1].start; li < subtrees[si + 1].end; ++li) {
           g.line_indices.push_back(li);
+        }
 
         extract_refs(lines, g.line_indices, g.write_var, g.read_vars);
         g.sort_key = g.write_var.empty() ? ref_si : g.write_var;
@@ -220,16 +311,22 @@ std::string canonicalize_dump(const std::string& filename) {
     ++si;
   }
 
-  int ng = static_cast<int>(groups.size());
+  int                           ng = static_cast<int>(groups.size());
   std::vector<std::vector<int>> adj(ng);
   std::vector<int>              in_degree(ng, 0);
 
   for (int a = 0; a < ng; ++a) {
     for (int b = a + 1; b < ng; ++b) {
       bool dep = false;
-      if (!groups[a].write_var.empty() && groups[b].read_vars.count(groups[a].write_var)) dep = true;
-      if (!groups[b].write_var.empty() && groups[a].read_vars.count(groups[b].write_var)) dep = true;
-      if (!groups[a].write_var.empty() && groups[a].write_var == groups[b].write_var) dep = true;
+      if (!groups[a].write_var.empty() && groups[b].read_vars.count(groups[a].write_var)) {
+        dep = true;
+      }
+      if (!groups[b].write_var.empty() && groups[a].read_vars.count(groups[b].write_var)) {
+        dep = true;
+      }
+      if (!groups[a].write_var.empty() && groups[a].write_var == groups[b].write_var) {
+        dep = true;
+      }
 
       if (dep) {
         adj[a].push_back(b);
@@ -239,13 +336,16 @@ std::string canonicalize_dump(const std::string& filename) {
   }
 
   auto cmp = [&groups](int a, int b) {
-    if (groups[a].sort_key != groups[b].sort_key)
+    if (groups[a].sort_key != groups[b].sort_key) {
       return groups[a].sort_key < groups[b].sort_key;
+    }
     return a < b;
   };
   std::set<int, decltype(cmp)> ready(cmp);
   for (int i = 0; i < ng; ++i) {
-    if (in_degree[i] == 0) ready.insert(i);
+    if (in_degree[i] == 0) {
+      ready.insert(i);
+    }
   }
 
   std::vector<int> sorted_order;
@@ -255,33 +355,44 @@ std::string canonicalize_dump(const std::string& filename) {
     ready.erase(ready.begin());
     sorted_order.push_back(u);
     for (int v : adj[u]) {
-      if (--in_degree[v] == 0) ready.insert(v);
+      if (--in_degree[v] == 0) {
+        ready.insert(v);
+      }
     }
   }
 
-  std::string result;
+  std::vector<std::string> reordered;
   for (int i = 0; i <= stmts_idx; ++i) {
-    result += lines[i];
-    result += '\n';
+    reordered.push_back(lines[i]);
   }
   for (int gi : sorted_order) {
     for (int li : groups[gi].line_indices) {
-      result += lines[li];
-      result += '\n';
+      reordered.push_back(lines[li]);
     }
   }
   int after_stmts = subtrees.back().end;
   for (int i = after_stmts; i < static_cast<int>(lines.size()); ++i) {
-    result += lines[i];
+    reordered.push_back(lines[i]);
+  }
+
+  canonicalize_commutative(reordered);
+
+  std::string result;
+  for (const auto& l : reordered) {
+    result += l;
     result += '\n';
   }
 
   std::string tmpl = "/tmp/hhds_semantic_XXXXXX";
-  int fd = mkstemp(tmpl.data());
-  if (fd == -1) return filename;
+  int         fd   = mkstemp(tmpl.data());
+  if (fd == -1) {
+    return filename;
+  }
   close(fd);
   std::ofstream ofs(tmpl);
-  if (!ofs.is_open()) return filename;
+  if (!ofs.is_open()) {
+    return filename;
+  }
   ofs << result;
   ofs.close();
 
@@ -289,12 +400,12 @@ std::string canonicalize_dump(const std::string& filename) {
 }
 
 struct DumpData {
-  DumpData() = default;
-  DumpData(DumpData&&) = default;
-  DumpData& operator=(DumpData&&) = default;
-  DumpData(const DumpData&) = delete;
+  DumpData()                           = default;
+  DumpData(DumpData&&)                 = default;
+  DumpData& operator=(DumpData&&)      = default;
+  DumpData(const DumpData&)            = delete;
   DumpData& operator=(const DumpData&) = delete;
-  
+
   std::shared_ptr<hhds::Tree>                     tree;
   std::vector<hhds::Tree::NodeData>               nodes;
   std::vector<std::string>                        type_names;
@@ -372,8 +483,8 @@ DumpData load_dump(const std::string& filename) {
       data.full_labels[data.nodes[i].pos] = contents[i];
     }
     if (contents.size() != data.nodes.size()) {
-      std::cerr << "hhds_tree_diff: label count mismatch in " << filename
-                << " (expected " << data.nodes.size() << ", got " << contents.size() << ")\n";
+      std::cerr << "hhds_tree_diff: label count mismatch in " << filename << " (expected " << data.nodes.size() << ", got "
+                << contents.size() << ")\n";
       data.tree.reset();
       return data;
     }
@@ -432,9 +543,9 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  const std::string file1 = argv[1];
-  const std::string file2 = argv[2];
-  const bool semantic = (argc == 4 && std::string(argv[3]) == "--semantic");
+  const std::string file1    = argv[1];
+  const std::string file2    = argv[2];
+  const bool        semantic = (argc == 4 && std::string(argv[3]) == "--semantic");
 
   std::string load_file1 = file1;
   std::string load_file2 = file2;
@@ -483,8 +594,12 @@ int main(int argc, char** argv) {
   std::cout << "Distance: " << result.distance << "\n";
 
   if (semantic) {
-    if (load_file1 != file1) std::remove(load_file1.c_str());
-    if (load_file2 != file2) std::remove(load_file2.c_str());
+    if (load_file1 != file1) {
+      std::remove(load_file1.c_str());
+    }
+    if (load_file2 != file2) {
+      std::remove(load_file2.c_str());
+    }
   }
 
   return 0;

--- a/hhds/tests/commutative_ops_test.cpp
+++ b/hhds/tests/commutative_ops_test.cpp
@@ -1,0 +1,304 @@
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+#include "gtest/gtest.h"
+
+namespace {
+
+std::string write_temp(const std::string& name, const std::string& content) {
+  std::string tmpl = "/tmp/hhds_commtest_" + name + "_XXXXXX";
+  int         fd   = mkstemp(tmpl.data());
+  EXPECT_NE(fd, -1) << "Cannot create temp file: " << tmpl;
+  if (fd == -1) {
+    return {};
+  }
+  close(fd);
+  std::ofstream ofs(tmpl);
+  EXPECT_TRUE(ofs.is_open()) << "Cannot open temp file: " << tmpl;
+  if (!ofs.is_open()) {
+    return {};
+  }
+  ofs << content;
+  return tmpl;
+}
+
+double run_diff(const std::string& file1, const std::string& file2, bool semantic) {
+  std::string binary    = "hhds/hhds_tree_diff";
+  const char* srcdir    = std::getenv("TEST_SRCDIR");
+  const char* workspace = std::getenv("TEST_WORKSPACE");
+  if (srcdir && workspace) {
+    binary = std::string(srcdir) + "/" + std::string(workspace) + "/" + binary;
+  }
+  std::string cmd = binary + " " + file1 + " " + file2;
+  if (semantic) {
+    cmd += " --semantic";
+  }
+  cmd += " 2>/dev/null";
+
+  FILE* pipe = popen(cmd.c_str(), "r");
+  if (!pipe) {
+    return -1;
+  }
+
+  double distance = -1;
+  char   buf[256];
+  while (fgets(buf, sizeof(buf), pipe)) {
+    std::string line(buf);
+    auto        pos = line.find("Distance: ");
+    if (pos != std::string::npos) {
+      distance = std::stod(line.substr(pos + 10));
+    }
+  }
+  pclose(pipe);
+  return distance;
+}
+
+// Each pair tests an op with operands in original vs swapped order.
+// All use the standard LNAST shape: first child = destination, rest = operands.
+
+// Helper to build a simple 2-operand expression dump
+std::string make_binop_dump(const std::string& name, const std::string& op, const std::string& op1, const std::string& op2) {
+  return name + "\n"
+       "└── top\n"
+       "    └── stmts\n"
+       "        └── " + op + "\n"
+       "            ├── ref '___1'\n"
+       "            ├── " + op1 + "\n"
+       "            └── " + op2 + "\n";
+}
+
+// Helper to build a 3-operand (N-ary) expression dump
+std::string make_ternop_dump(const std::string& name, const std::string& op, const std::string& op1, const std::string& op2,
+                             const std::string& op3) {
+  return name + "\n"
+       "└── top\n"
+       "    └── stmts\n"
+       "        └── " + op + "\n"
+       "            ├── ref '___1'\n"
+       "            ├── " + op1 + "\n"
+       "            ├── " + op2 + "\n"
+       "            └── " + op3 + "\n";
+}
+
+// Combined: statement reordering + commutative op
+// a = 1; b = 2; c = a + b  vs  b = 2; a = 1; c = b + a
+const std::string combined_original
+    = "combined_orig\n"
+      "└── top\n"
+      "    └── stmts\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'a'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        ├── assign\n"
+      "        │   ├── ref 'a'\n"
+      "        │   └── const '1'\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'b'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        ├── assign\n"
+      "        │   ├── ref 'b'\n"
+      "        │   └── const '2'\n"
+      "        ├── plus\n"
+      "        │   ├── ref '___1'\n"
+      "        │   ├── ref 'a'\n"
+      "        │   └── ref 'b'\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'c'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const 'mut'\n"
+      "        └── assign\n"
+      "            ├── ref 'c'\n"
+      "            └── ref '___1'\n";
+
+const std::string combined_swapped
+    = "combined_swap\n"
+      "└── top\n"
+      "    └── stmts\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'b'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        ├── assign\n"
+      "        │   ├── ref 'b'\n"
+      "        │   └── const '2'\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'a'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const\n"
+      "        ├── assign\n"
+      "        │   ├── ref 'a'\n"
+      "        │   └── const '1'\n"
+      "        ├── plus\n"
+      "        │   ├── ref '___1'\n"
+      "        │   ├── ref 'b'\n"
+      "        │   └── ref 'a'\n"
+      "        ├── attr_set\n"
+      "        │   ├── ref 'c'\n"
+      "        │   ├── const 'type'\n"
+      "        │   └── const 'mut'\n"
+      "        └── assign\n"
+      "            ├── ref 'c'\n"
+      "            └── ref '___1'\n";
+
+}  // namespace
+
+
+class CommutativeOpsTest : public ::testing::Test {
+protected:
+  std::vector<std::string> temp_files;
+
+  std::string make_temp(const std::string& name, const std::string& content) {
+    auto path = write_temp(name, content);
+    if (!path.empty()) {
+      temp_files.push_back(path);
+    }
+    return path;
+  }
+
+  void TearDown() override {
+    for (const auto& f : temp_files) {
+      std::remove(f.c_str());
+    }
+  }
+
+  // Test a commutative op: swapped operands should give distance 0 in semantic mode
+  void test_commutative(const std::string& op_name, const std::string& op1, const std::string& op2) {
+    auto dump_a = make_binop_dump("test_a", op_name, op1, op2);
+    auto dump_b = make_binop_dump("test_b", op_name, op2, op1);
+    auto f1     = make_temp(op_name + "_a", dump_a);
+    auto f2     = make_temp(op_name + "_b", dump_b);
+
+    double plain    = run_diff(f1, f2, false);
+    double semantic = run_diff(f1, f2, true);
+
+    EXPECT_GT(plain, 0.0) << op_name << ": plain diff should detect swapped operands";
+    EXPECT_EQ(semantic, 0.0) << op_name << ": semantic diff should give 0 for swapped operands";
+  }
+
+  // Test a non-commutative op: swapped operands should give distance > 0 even in semantic mode
+  void test_non_commutative(const std::string& op_name, const std::string& op1, const std::string& op2) {
+    auto dump_a = make_binop_dump("test_a", op_name, op1, op2);
+    auto dump_b = make_binop_dump("test_b", op_name, op2, op1);
+    auto f1     = make_temp(op_name + "_nc_a", dump_a);
+    auto f2     = make_temp(op_name + "_nc_b", dump_b);
+
+    double semantic = run_diff(f1, f2, true);
+    EXPECT_GT(semantic, 0.0) << op_name << ": non-commutative op should NOT give 0 for swapped operands";
+  }
+};
+
+// ─── Commutative operations: swapped operands → distance 0 ──────────
+
+TEST_F(CommutativeOpsTest, Plus_Commutative) { test_commutative("plus", "ref 'x'", "ref 'y'"); }
+
+TEST_F(CommutativeOpsTest, Mult_Commutative) { test_commutative("mult", "ref 'a'", "ref 'b'"); }
+
+TEST_F(CommutativeOpsTest, BitAnd_Commutative) { test_commutative("bit_and", "ref 'p'", "ref 'q'"); }
+
+TEST_F(CommutativeOpsTest, BitOr_Commutative) { test_commutative("bit_or", "ref 'm'", "ref 'n'"); }
+
+TEST_F(CommutativeOpsTest, BitXor_Commutative) { test_commutative("bit_xor", "ref 's'", "ref 't'"); }
+
+TEST_F(CommutativeOpsTest, LogAnd_Commutative) { test_commutative("log_and", "ref 'c1'", "ref 'c2'"); }
+
+TEST_F(CommutativeOpsTest, LogOr_Commutative) { test_commutative("log_or", "ref 'd1'", "ref 'd2'"); }
+
+TEST_F(CommutativeOpsTest, Eq_Commutative) { test_commutative("eq", "ref 'lhs'", "ref 'rhs'"); }
+
+TEST_F(CommutativeOpsTest, Ne_Commutative) { test_commutative("ne", "ref 'val1'", "ref 'val2'"); }
+
+// ─── Commutative with constants ──────────────────────────────────────
+
+TEST_F(CommutativeOpsTest, Plus_RefAndConst) { test_commutative("plus", "ref 'x'", "const '5'"); }
+
+TEST_F(CommutativeOpsTest, Eq_TwoConsts) { test_commutative("eq", "const '1'", "const '2'"); }
+
+// ─── Non-commutative operations: swapped operands → distance > 0 ────
+
+TEST_F(CommutativeOpsTest, Minus_NonCommutative) { test_non_commutative("minus", "ref 'x'", "ref 'y'"); }
+
+TEST_F(CommutativeOpsTest, Div_NonCommutative) { test_non_commutative("div", "ref 'a'", "ref 'b'"); }
+
+TEST_F(CommutativeOpsTest, Mod_NonCommutative) { test_non_commutative("mod", "ref 'a'", "ref 'b'"); }
+
+TEST_F(CommutativeOpsTest, Shl_NonCommutative) { test_non_commutative("shl", "ref 'x'", "const '2'"); }
+
+TEST_F(CommutativeOpsTest, Sra_NonCommutative) { test_non_commutative("sra", "ref 'x'", "const '1'"); }
+
+TEST_F(CommutativeOpsTest, Lt_NonCommutative) { test_non_commutative("lt", "ref 'a'", "ref 'b'"); }
+
+TEST_F(CommutativeOpsTest, Le_NonCommutative) { test_non_commutative("le", "ref 'a'", "ref 'b'"); }
+
+TEST_F(CommutativeOpsTest, Gt_NonCommutative) { test_non_commutative("gt", "ref 'a'", "ref 'b'"); }
+
+TEST_F(CommutativeOpsTest, Ge_NonCommutative) { test_non_commutative("ge", "ref 'a'", "ref 'b'"); }
+
+// ─── N-ary commutative: 3 operands ──────────────────────────────────
+
+TEST_F(CommutativeOpsTest, Plus_ThreeOperands_AllPermutations) {
+  auto dump_abc = make_ternop_dump("abc", "plus", "ref 'a'", "ref 'b'", "ref 'c'");
+  auto dump_cab = make_ternop_dump("cab", "plus", "ref 'c'", "ref 'a'", "ref 'b'");
+  auto dump_bca = make_ternop_dump("bca", "plus", "ref 'b'", "ref 'c'", "ref 'a'");
+
+  auto f_abc = make_temp("nary_abc", dump_abc);
+  auto f_cab = make_temp("nary_cab", dump_cab);
+  auto f_bca = make_temp("nary_bca", dump_bca);
+
+  EXPECT_EQ(run_diff(f_abc, f_cab, true), 0.0) << "plus(a,b,c) ≡ plus(c,a,b)";
+  EXPECT_EQ(run_diff(f_abc, f_bca, true), 0.0) << "plus(a,b,c) ≡ plus(b,c,a)";
+  EXPECT_EQ(run_diff(f_cab, f_bca, true), 0.0) << "plus(c,a,b) ≡ plus(b,c,a)";
+}
+
+// ─── Destination preserved ───────────────────────────────────────────
+
+TEST_F(CommutativeOpsTest, DestinationNotSorted) {
+  auto dump_a = make_binop_dump("dst_a", "plus", "ref 'a'", "ref 'b'");
+  auto dump_b = make_binop_dump("dst_b", "plus", "ref 'b'", "ref 'a'");
+  auto f1     = make_temp("dst_test_a", dump_a);
+  auto f2     = make_temp("dst_test_b", dump_b);
+
+  EXPECT_EQ(run_diff(f1, f2, true), 0.0) << "Destination should stay in place";
+}
+
+// ─── Identical commutative ops → distance 0 ─────────────────────────
+
+TEST_F(CommutativeOpsTest, Identical_StillZero) {
+  auto dump = make_binop_dump("same", "plus", "ref 'x'", "ref 'y'");
+  auto f1   = make_temp("id_a", dump);
+  auto f2   = make_temp("id_b", dump);
+
+  EXPECT_EQ(run_diff(f1, f2, true), 0.0);
+  EXPECT_EQ(run_diff(f1, f2, false), 0.0);
+}
+
+// ─── Combined: statement reordering + commutative ops ────────────────
+
+TEST_F(CommutativeOpsTest, Combined_StmtReorder_PlusSwap) {
+  auto f1 = make_temp("comb_a", combined_original);
+  auto f2 = make_temp("comb_b", combined_swapped);
+
+  double plain    = run_diff(f1, f2, false);
+  double semantic = run_diff(f1, f2, true);
+
+  EXPECT_GT(plain, 0.0) << "Plain diff should detect both reordering and operand swap";
+  EXPECT_EQ(semantic, 0.0) << "Semantic diff should handle statement reordering + commutative operand swap together";
+}
+
+// ─── Symmetry ────────────────────────────────────────────────────────
+
+TEST_F(CommutativeOpsTest, Symmetry) {
+  auto dump_a = make_binop_dump("sym_a", "plus", "ref 'x'", "ref 'y'");
+  auto dump_b = make_binop_dump("sym_b", "plus", "ref 'y'", "ref 'x'");
+  auto f1     = make_temp("sym_1", dump_a);
+  auto f2     = make_temp("sym_2", dump_b);
+
+  double ab = run_diff(f1, f2, true);
+  double ba = run_diff(f2, f1, true);
+  EXPECT_EQ(ab, ba) << "Semantic diff should be symmetric for commutative ops";
+}

--- a/hhds/tree.hpp
+++ b/hhds/tree.hpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <bitset>
 #include <cassert>
 #include <cstddef>


### PR DESCRIPTION
Note: merge after this PR : [https://github.com/masc-ucsc/hhds/pull/221](https://github.com/masc-ucsc/hhds/pull/221)

## Summary

Adds a comprehensive test suite for commutative operation canonicalization in `hhds_tree_diff`, verifying that all commutative operations produce distance 0 when operands are swapped, and all non-commutative operations correctly preserve non-zero distances.

## Files Added

* `hhds/tests/commutative_ops_test.cpp` — 28 test cases
* `hhds/BUILD.bazel` — added `cc_test` target for `commutative_ops_test`

## Test Cases (28 total)

| Category | Count | What |
|----------|-------|------|
| Commutative ops | 9 | plus, mult, bit_and, bit_or, bit_xor, log_and, log_or, eq, ne |
| With constants | 2 | ref+const, const+const operands |
| Non-commutative ops | 9 | minus, div, mod, shl, sra, lt, le, gt, ge |
| N-ary operands | 1 | All permutations of plus(a,b,c) |
| Destination preserved | 1 | First child not sorted |
| Identical ops | 1 | Same tree → 0 in both modes |
| Combined | 1 | Statement reorder + operand swap together |
| Symmetry | 1 | dist(A,B) == dist(B,A) |

## Test Output

```
bazel test //hhds:commutative_ops_test
//hhds:commutative_ops_test    PASSED in 0.3s
```