### PR TITLE
benchmarks_final: vector PDF plots, smoke test, parallel companion runner

### DIFF
--- a/hhds/benchmarks_final/scripts/plot_results.py
+++ b/hhds/benchmarks_final/scripts/plot_results.py
@@ -13,6 +13,22 @@ os.environ.setdefault("MPLCONFIGDIR", str(Path(tempfile.gettempdir()) / "hhds_be
 
 import matplotlib.pyplot as plt
 
+# Roughly 2x matplotlib defaults for everything near the axes -- title, axis
+# labels, tick labels -- so the plots are readable in the thesis PDF without
+# zooming (reviewer request). The legend is intentionally kept small (it is
+# not a label and the figure caption already names the libraries).
+plt.rcParams.update({
+    "font.size":        20,
+    "axes.titlesize":   24,
+    "axes.titlepad":    14,  # extra breathing room between title and axes
+    "axes.labelsize":   22,
+    "xtick.labelsize":  20,
+    "ytick.labelsize":  20,
+    "legend.fontsize":  18,  # color key for the libraries, sits below the plot
+    "lines.linewidth":  2.5,
+    "lines.markersize": 9,
+})
+
 
 LIBRARIES = ("hhds", "livehd", "boost")
 COLORS = {
@@ -48,7 +64,12 @@ def main():
 
     for (operation, scenario, x_axis), rows in sorted(groups.items()):
         rows.sort(key=lambda row: int(row["x_value"]))
-        fig, ax = plt.subplots(figsize=(8, 5))
+        # constrained_layout is the only layout engine that properly accounts
+        # for the out-of-axes legend (set via bbox_to_anchor below). The
+        # earlier combination of tight_layout() + bbox_inches="tight" left
+        # the title visibly hugging the top because tight_layout doesn't see
+        # the legend at all.
+        fig, ax = plt.subplots(figsize=(8, 6.5), constrained_layout=True)
 
         plotted = False
         for library in LIBRARIES:
@@ -73,14 +94,24 @@ def main():
         time_unit = rows[0].get("time_unit", "ns/op")
         ax.set_ylabel(f"median time ({time_unit})")
         ax.grid(True, which="both", linestyle="--", alpha=0.35)
-        ax.legend()
+        # Place the legend OUTSIDE the axes, below the x-axis, as a single
+        # horizontal row. Guarantees zero overlap with any data line and
+        # stays in the same place across all panels.
+        ax.legend(
+            loc="upper center",
+            bbox_to_anchor=(0.5, -0.18),
+            ncol=3,
+            frameon=False,
+        )
         if all(int(row["x_value"]) > 0 for row in rows):
             ax.set_xscale("log")
         ax.set_yscale("log")
-        fig.tight_layout()
+        # No fig.tight_layout(); constrained_layout already handles spacing.
 
-        name = safe_name(f"{operation}_{scenario}_{x_axis}.png")
-        fig.savefig(out_dir / name, dpi=160)
+        # Vector PDF output: crisp at any zoom, selectable text, print-quality.
+        # dpi is irrelevant for a vector format.
+        name = safe_name(f"{operation}_{scenario}_{x_axis}.pdf")
+        fig.savefig(out_dir / name)
         plt.close(fig)
 
 

--- a/hhds/benchmarks_final/scripts/run_all.sh
+++ b/hhds/benchmarks_final/scripts/run_all.sh
@@ -17,13 +17,30 @@ COMPARISON_CSV="$BENCH_DIR/comparisons/comparison.csv"
 PLOT_DIR="$BENCH_DIR/comparisons/plot"
 
 RUNS="${RUNS:-5}"
-NODE_SIZES="${NODE_SIZES:-100 1000 10000}"
-PIN_SIZES="${PIN_SIZES:-2 4 8 16 32}"
-HIER_NODE_SIZES="${HIER_NODE_SIZES:-100 1000}"
-HIER_SIZES="${HIER_SIZES:-10 100 1000}"
-PIN_NODE_COUNT="${PIN_NODE_COUNT:-10000}"
+
+# Revision 4: sizes bumped per professor feedback so each cell exceeds 1 s of
+# wall time wherever possible. Override any of these on the command line.
+NODE_SIZES="${NODE_SIZES:-10000 100000 1000000 10000000}"
+PIN_SIZES="${PIN_SIZES:-8 32 128 512 2048}"
+HIER_NODE_SIZES="${HIER_NODE_SIZES:-10000 100000}"
+HIER_SIZES="${HIER_SIZES:-1000 10000}"
+PIN_NODE_COUNT="${PIN_NODE_COUNT:-100000}"
 FIXED_HIER_SIZE="${FIXED_HIER_SIZE:-100}"
-HIER_RANGE_NODE_COUNT="${HIER_RANGE_NODE_COUNT:-1000}"
+HIER_RANGE_NODE_COUNT="${HIER_RANGE_NODE_COUNT:-10000}"
+
+# Per-library overrides — set these to cap a library that runs out of memory
+# at the largest sizes (LiveHD especially). Default to the common values above.
+HHDS_NODE_SIZES="${HHDS_NODE_SIZES:-$NODE_SIZES}"
+BOOST_NODE_SIZES="${BOOST_NODE_SIZES:-$NODE_SIZES}"
+LIVEHD_NODE_SIZES="${LIVEHD_NODE_SIZES:-$NODE_SIZES}"
+HHDS_PIN_SIZES="${HHDS_PIN_SIZES:-$PIN_SIZES}"
+LIVEHD_PIN_SIZES="${LIVEHD_PIN_SIZES:-$PIN_SIZES}"
+HHDS_HIER_NODE_SIZES="${HHDS_HIER_NODE_SIZES:-$HIER_NODE_SIZES}"
+LIVEHD_HIER_NODE_SIZES="${LIVEHD_HIER_NODE_SIZES:-$HIER_NODE_SIZES}"
+HHDS_HIER_SIZES="${HHDS_HIER_SIZES:-$HIER_SIZES}"
+LIVEHD_HIER_SIZES="${LIVEHD_HIER_SIZES:-$HIER_SIZES}"
+HHDS_PIN_NODE_COUNT="${HHDS_PIN_NODE_COUNT:-$PIN_NODE_COUNT}"
+LIVEHD_PIN_NODE_COUNT="${LIVEHD_PIN_NODE_COUNT:-$PIN_NODE_COUNT}"
 
 if [[ -x "$REPO_ROOT/hhds/bench/.venv/bin/python" ]]; then
   PYTHON="${PYTHON:-$REPO_ROOT/hhds/bench/.venv/bin/python}"
@@ -39,6 +56,55 @@ if [[ -f "$LIVEHD_ROOT/lgraph/tests/livehd_final_bench.cpp" ]]; then
   echo "Building LiveHD benchmark..."
   (cd "$LIVEHD_ROOT" && bazel build //lgraph:livehd_final_bench)
   LIVEHD_AVAILABLE=1
+fi
+
+# SMOKE_ONLY=1 runs the heaviest cells once each, prints OK/FAILED per cell,
+# and exits without touching the CSVs. Use this to catch OOMs before kicking
+# off the full multi-hour sweep. Cells are timed-out after 10 minutes.
+if [[ "${SMOKE_ONLY:-0}" == "1" ]]; then
+  echo ""
+  echo "==> SMOKE TEST (max sizes, single run, no CSV output)"
+  # macOS doesn't ship GNU `timeout`; use `gtimeout` from coreutils if present,
+  # otherwise run without a wall-clock cap.
+  if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_CMD=(timeout 600)
+  elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_CMD=(gtimeout 600)
+  else
+    TIMEOUT_CMD=()
+    echo "    (no timeout/gtimeout available -- cells will run to completion)"
+  fi
+  smoke() {
+    local name="$1"; local bin="$2"; local op="$3"; local scenario="$4"; local n="$5"
+    printf "  %-7s n=%-9s %-12s:%-15s ... " "$name" "$n" "$op" "$scenario"
+    local start=$SECONDS
+    local stderr_log
+    stderr_log=$(mktemp)
+    if ${TIMEOUT_CMD[@]+"${TIMEOUT_CMD[@]}"} "$bin" --op="$op" --scenario="$scenario" \
+         --nodes="$n" --pins=1 --hier="$FIXED_HIER_SIZE" --k=0 --runs=1 --no-header \
+         > /dev/null 2> "$stderr_log"; then
+      echo "OK ($((SECONDS - start)) s)"
+    else
+      echo "FAILED after $((SECONDS - start)) s -- stderr:"
+      sed 's/^/      /' "$stderr_log" | head -5
+    fi
+    rm -f "$stderr_log"
+  }
+  for size in $NODE_SIZES; do
+    smoke "HHDS"   "$HHDS_BIN"   add_nodes default  "$size"
+    smoke "HHDS"   "$HHDS_BIN"   add_edges overflow "$size"
+    smoke "Boost"  "$BOOST_BIN"  add_nodes default  "$size"
+    smoke "Boost"  "$BOOST_BIN"  add_edges overflow "$size"
+    if [[ "$LIVEHD_AVAILABLE" == "1" ]]; then
+      smoke "LiveHD" "$LIVEHD_BIN" add_nodes default  "$size"
+      smoke "LiveHD" "$LIVEHD_BIN" add_edges overflow "$size"
+    fi
+    echo ""
+  done
+  echo "==> Smoke test complete. If any cell FAILED, cap that library via"
+  echo "    LIVEHD_NODE_SIZES / BOOST_NODE_SIZES / HHDS_NODE_SIZES before"
+  echo "    rerunning without SMOKE_ONLY."
+  exit 0
 fi
 
 mkdir -p "$BENCH_DIR/hhds" "$BENCH_DIR/boost" "$BENCH_DIR/livehd" "$BENCH_DIR/comparisons" "$PLOT_DIR"
@@ -58,35 +124,48 @@ run_one() {
   local hier="$8"
   local k="$9"
 
-  "$bin" \
-    --op="$op" \
-    --scenario="$scenario" \
-    --x-axis="$x_axis" \
-    --nodes="$nodes" \
-    --pins="$pins" \
-    --hier="$hier" \
-    --k="$k" \
-    --runs="$RUNS" \
-    --no-header >> "$out"
+  local label
+  label="$(basename "$bin")"
+  printf "  %-25s op=%-32s scenario=%-15s nodes=%-10s pins=%-5s hier=%-5s ... " \
+    "$label" "$op" "$scenario" "$nodes" "$pins" "$hier"
+  local start=$SECONDS
+
+  # A failed cell (e.g. a library that can't handle a given size) just leaves
+  # no rows in the CSV -- the comparison stage renders that as N/A -- instead
+  # of aborting the whole multi-hour sweep.
+  if "$bin" \
+       --op="$op" \
+       --scenario="$scenario" \
+       --x-axis="$x_axis" \
+       --nodes="$nodes" \
+       --pins="$pins" \
+       --hier="$hier" \
+       --k="$k" \
+       --runs="$RUNS" \
+       --no-header >> "$out" 2>/dev/null; then
+    echo "OK ($((SECONDS - start)) s)"
+  else
+    echo "FAILED ($((SECONDS - start)) s) -- skipping cell"
+  fi
 }
 
 echo "Running HHDS benchmarks..."
-for nodes in $NODE_SIZES; do
+for nodes in $HHDS_NODE_SIZES; do
   run_one "$HHDS_BIN" "$HHDS_CSV" add_nodes default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
   run_one "$HHDS_BIN" "$HHDS_CSV" add_nodes_with_pins default nodes "$nodes" 8 "$FIXED_HIER_SIZE" 0
   run_one "$HHDS_BIN" "$HHDS_CSV" lookup_nodes default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
   run_one "$HHDS_BIN" "$HHDS_CSV" delete_nodes_with_edges_and_pins default nodes "$nodes" 8 "$FIXED_HIER_SIZE" 0
 done
 
-for pins in $PIN_SIZES; do
-  run_one "$HHDS_BIN" "$HHDS_CSV" add_pins default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
-  run_one "$HHDS_BIN" "$HHDS_CSV" delete_pins default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
-  run_one "$HHDS_BIN" "$HHDS_CSV" delete_pins_with_edges default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
-  run_one "$HHDS_BIN" "$HHDS_CSV" lookup_pins default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+for pins in $HHDS_PIN_SIZES; do
+  run_one "$HHDS_BIN" "$HHDS_CSV" add_pins default pins "$HHDS_PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+  run_one "$HHDS_BIN" "$HHDS_CSV" delete_pins default pins "$HHDS_PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+  run_one "$HHDS_BIN" "$HHDS_CSV" delete_pins_with_edges default pins "$HHDS_PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+  run_one "$HHDS_BIN" "$HHDS_CSV" lookup_pins default pins "$HHDS_PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
 done
 
 for scenario in sedges_inline ledge_inline overflow; do
-  for nodes in $NODE_SIZES; do
+  for nodes in $HHDS_NODE_SIZES; do
     run_one "$HHDS_BIN" "$HHDS_CSV" add_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
     run_one "$HHDS_BIN" "$HHDS_CSV" delete_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
     run_one "$HHDS_BIN" "$HHDS_CSV" lookup_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
@@ -96,7 +175,7 @@ for scenario in sedges_inline ledge_inline overflow; do
   done
 done
 
-for nodes in $HIER_NODE_SIZES; do
+for nodes in $HHDS_HIER_NODE_SIZES; do
   run_one "$HHDS_BIN" "$HHDS_CSV" traverse_fast_flat default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
   run_one "$HHDS_BIN" "$HHDS_CSV" traverse_forward_flat default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
   run_one "$HHDS_BIN" "$HHDS_CSV" traverse_backward_flat default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
@@ -105,19 +184,19 @@ for nodes in $HIER_NODE_SIZES; do
   run_one "$HHDS_BIN" "$HHDS_CSV" traverse_backward_hier default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
 done
 
-for hier in $HIER_SIZES; do
+for hier in $HHDS_HIER_SIZES; do
   run_one "$HHDS_BIN" "$HHDS_CSV" traverse_hier_range default hier "$HIER_RANGE_NODE_COUNT" 1 "$hier" 0
 done
 
 echo "Running Boost benchmarks..."
-for nodes in $NODE_SIZES; do
+for nodes in $BOOST_NODE_SIZES; do
   run_one "$BOOST_BIN" "$BOOST_CSV" add_nodes default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
   run_one "$BOOST_BIN" "$BOOST_CSV" lookup_nodes default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
   run_one "$BOOST_BIN" "$BOOST_CSV" delete_nodes_with_edges_and_pins default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
 done
 
 for scenario in sedges_inline ledge_inline overflow; do
-  for nodes in $NODE_SIZES; do
+  for nodes in $BOOST_NODE_SIZES; do
     run_one "$BOOST_BIN" "$BOOST_CSV" add_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
     run_one "$BOOST_BIN" "$BOOST_CSV" delete_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
     run_one "$BOOST_BIN" "$BOOST_CSV" lookup_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
@@ -129,22 +208,22 @@ done
 
 if [[ "$LIVEHD_AVAILABLE" == "1" ]]; then
   echo "Running LiveHD benchmarks..."
-  for nodes in $NODE_SIZES; do
+  for nodes in $LIVEHD_NODE_SIZES; do
     run_one "$LIVEHD_BIN" "$LIVEHD_CSV" add_nodes default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
     run_one "$LIVEHD_BIN" "$LIVEHD_CSV" add_nodes_with_pins default nodes "$nodes" 8 "$FIXED_HIER_SIZE" 0
     run_one "$LIVEHD_BIN" "$LIVEHD_CSV" lookup_nodes default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
     run_one "$LIVEHD_BIN" "$LIVEHD_CSV" delete_nodes_with_edges_and_pins default nodes "$nodes" 8 "$FIXED_HIER_SIZE" 0
   done
 
-  for pins in $PIN_SIZES; do
-    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" add_pins default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
-    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" delete_pins default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
-    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" delete_pins_with_edges default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
-    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" lookup_pins default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+  for pins in $LIVEHD_PIN_SIZES; do
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" add_pins default pins "$LIVEHD_PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" delete_pins default pins "$LIVEHD_PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" delete_pins_with_edges default pins "$LIVEHD_PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" lookup_pins default pins "$LIVEHD_PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
   done
 
   for scenario in sedges_inline ledge_inline overflow; do
-    for nodes in $NODE_SIZES; do
+    for nodes in $LIVEHD_NODE_SIZES; do
       run_one "$LIVEHD_BIN" "$LIVEHD_CSV" add_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
       run_one "$LIVEHD_BIN" "$LIVEHD_CSV" delete_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
       run_one "$LIVEHD_BIN" "$LIVEHD_CSV" lookup_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
@@ -155,14 +234,14 @@ if [[ "$LIVEHD_AVAILABLE" == "1" ]]; then
     done
   done
 
-  for nodes in $HIER_NODE_SIZES; do
+  for nodes in $LIVEHD_HIER_NODE_SIZES; do
     run_one "$LIVEHD_BIN" "$LIVEHD_CSV" traverse_fast_flat default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
     run_one "$LIVEHD_BIN" "$LIVEHD_CSV" traverse_forward_flat default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
     run_one "$LIVEHD_BIN" "$LIVEHD_CSV" traverse_fast_hier default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
     run_one "$LIVEHD_BIN" "$LIVEHD_CSV" traverse_forward_hier default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
   done
 
-  for hier in $HIER_SIZES; do
+  for hier in $LIVEHD_HIER_SIZES; do
     run_one "$LIVEHD_BIN" "$LIVEHD_CSV" traverse_hier_range default hier "$HIER_RANGE_NODE_COUNT" 1 "$hier" 0
   done
 else

--- a/hhds/benchmarks_final/smaller_benchmarks/run_smaller.sh
+++ b/hhds/benchmarks_final/smaller_benchmarks/run_smaller.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Fast companion to ../scripts/run_all.sh -- smaller sizes, 3 runs, runs the
+# three libraries (HHDS, Boost, LiveHD) in parallel. All output stays inside
+# this directory (hhds/benchmarks_final/smaller_benchmarks/) so it does not
+# collide with the slow run's CSVs at the parent benchmarks_final/ level.
+#
+# Safe to run while ../scripts/run_all.sh is still grinding in the background;
+# the only shared resource is the bazel-bin/ benchmark binaries (read-only).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BENCH_DIR="$REPO_ROOT/hhds/benchmarks_final"
+SMALL_DIR="$SCRIPT_DIR"
+
+HHDS_BIN="$REPO_ROOT/bazel-bin/hhds/benchmarks_final/hhds/hhds_final_bench"
+BOOST_BIN="$REPO_ROOT/bazel-bin/hhds/benchmarks_final/boost/boost_final_bench"
+LIVEHD_ROOT="${LIVEHD_ROOT:-$(cd "$REPO_ROOT/.." && pwd)/livehd}"
+LIVEHD_BIN="$LIVEHD_ROOT/bazel-bin/lgraph/livehd_final_bench"
+
+HHDS_CSV="$SMALL_DIR/hhds/results.csv"
+BOOST_CSV="$SMALL_DIR/boost/results.csv"
+LIVEHD_CSV="$SMALL_DIR/livehd/results.csv"
+COMPARISON_CSV="$SMALL_DIR/comparisons/comparison.csv"
+PLOT_DIR="$SMALL_DIR/comparisons/plot"
+LOG_DIR="$SMALL_DIR/logs"
+
+RUNS="${RUNS:-3}"
+NODE_SIZES="${NODE_SIZES:-1000 5000 10000 50000 100000 500000 1000000 5000000}"
+PIN_SIZES="${PIN_SIZES:-4 8 16 32 64}"
+HIER_NODE_SIZES="${HIER_NODE_SIZES:-10000 100000}"
+HIER_SIZES="${HIER_SIZES:-1000 10000}"
+PIN_NODE_COUNT="${PIN_NODE_COUNT:-100000}"
+FIXED_HIER_SIZE="${FIXED_HIER_SIZE:-100}"
+HIER_RANGE_NODE_COUNT="${HIER_RANGE_NODE_COUNT:-10000}"
+
+if [[ -x "$REPO_ROOT/hhds/bench/.venv/bin/python" ]]; then
+  PYTHON="${PYTHON:-$REPO_ROOT/hhds/bench/.venv/bin/python}"
+else
+  PYTHON="${PYTHON:-python3}"
+fi
+
+# Verify binaries already exist -- this script does NOT trigger bazel build,
+# the slow run owns that. If the binaries are missing, ask the user to wait
+# for the slow run's build step or build manually.
+for bin in "$HHDS_BIN" "$BOOST_BIN"; do
+  if [[ ! -x "$bin" ]]; then
+    echo "ERROR: required binary not built: $bin" >&2
+    echo "       Run 'bazel build //hhds/benchmarks_final/hhds:hhds_final_bench //hhds/benchmarks_final/boost:boost_final_bench'" >&2
+    echo "       (or wait for ../scripts/run_all.sh to finish its bazel step first)" >&2
+    exit 1
+  fi
+done
+LIVEHD_AVAILABLE=0
+if [[ -x "$LIVEHD_BIN" ]]; then
+  LIVEHD_AVAILABLE=1
+fi
+
+mkdir -p "$SMALL_DIR/hhds" "$SMALL_DIR/boost" "$SMALL_DIR/livehd" \
+         "$SMALL_DIR/comparisons" "$PLOT_DIR" "$LOG_DIR"
+
+HEADER="library,operation,scenario,x_axis,x_value,nodes,pins_per_node,hier_size,k,run_idx,wall_ns,items"
+printf '%s\n' "$HEADER" > "$HHDS_CSV"
+printf '%s\n' "$HEADER" > "$BOOST_CSV"
+printf '%s\n' "$HEADER" > "$LIVEHD_CSV"
+
+run_one() {
+  local bin="$1"
+  local out="$2"
+  local op="$3"
+  local scenario="$4"
+  local x_axis="$5"
+  local nodes="$6"
+  local pins="$7"
+  local hier="$8"
+  local k="$9"
+
+  local label
+  label="$(basename "$bin")"
+  printf "  %-25s op=%-32s scenario=%-15s nodes=%-10s pins=%-5s hier=%-5s ... " \
+    "$label" "$op" "$scenario" "$nodes" "$pins" "$hier"
+  local start=$SECONDS
+
+  # A failed cell (e.g. LiveHD overflow >= 10k) just leaves no rows in the CSV
+  # -- the comparison stage renders that as N/A -- instead of aborting the
+  # whole parallel sweep.
+  if "$bin" \
+       --op="$op" \
+       --scenario="$scenario" \
+       --x-axis="$x_axis" \
+       --nodes="$nodes" \
+       --pins="$pins" \
+       --hier="$hier" \
+       --k="$k" \
+       --runs="$RUNS" \
+       --no-header >> "$out" 2>/dev/null; then
+    echo "OK ($((SECONDS - start)) s)"
+  else
+    echo "FAILED ($((SECONDS - start)) s) -- skipping cell"
+  fi
+}
+
+run_hhds_all() {
+  for nodes in $NODE_SIZES; do
+    run_one "$HHDS_BIN" "$HHDS_CSV" add_nodes default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    run_one "$HHDS_BIN" "$HHDS_CSV" add_nodes_with_pins default nodes "$nodes" 8 "$FIXED_HIER_SIZE" 0
+    run_one "$HHDS_BIN" "$HHDS_CSV" lookup_nodes default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    run_one "$HHDS_BIN" "$HHDS_CSV" delete_nodes_with_edges_and_pins default nodes "$nodes" 8 "$FIXED_HIER_SIZE" 0
+  done
+  for pins in $PIN_SIZES; do
+    run_one "$HHDS_BIN" "$HHDS_CSV" add_pins default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+    run_one "$HHDS_BIN" "$HHDS_CSV" delete_pins default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+    run_one "$HHDS_BIN" "$HHDS_CSV" delete_pins_with_edges default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+    run_one "$HHDS_BIN" "$HHDS_CSV" lookup_pins default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+  done
+  for scenario in sedges_inline ledge_inline overflow; do
+    for nodes in $NODE_SIZES; do
+      run_one "$HHDS_BIN" "$HHDS_CSV" add_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      run_one "$HHDS_BIN" "$HHDS_CSV" delete_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      run_one "$HHDS_BIN" "$HHDS_CSV" lookup_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      run_one "$HHDS_BIN" "$HHDS_CSV" traverse_fast_class "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      run_one "$HHDS_BIN" "$HHDS_CSV" traverse_forward_class "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      run_one "$HHDS_BIN" "$HHDS_CSV" traverse_backward_class "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    done
+  done
+  for nodes in $HIER_NODE_SIZES; do
+    run_one "$HHDS_BIN" "$HHDS_CSV" traverse_fast_flat default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    run_one "$HHDS_BIN" "$HHDS_CSV" traverse_forward_flat default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    run_one "$HHDS_BIN" "$HHDS_CSV" traverse_backward_flat default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    run_one "$HHDS_BIN" "$HHDS_CSV" traverse_fast_hier default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    run_one "$HHDS_BIN" "$HHDS_CSV" traverse_forward_hier default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    run_one "$HHDS_BIN" "$HHDS_CSV" traverse_backward_hier default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+  done
+  for hier in $HIER_SIZES; do
+    run_one "$HHDS_BIN" "$HHDS_CSV" traverse_hier_range default hier "$HIER_RANGE_NODE_COUNT" 1 "$hier" 0
+  done
+}
+
+run_boost_all() {
+  for nodes in $NODE_SIZES; do
+    run_one "$BOOST_BIN" "$BOOST_CSV" add_nodes default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    run_one "$BOOST_BIN" "$BOOST_CSV" lookup_nodes default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    run_one "$BOOST_BIN" "$BOOST_CSV" delete_nodes_with_edges_and_pins default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+  done
+  for scenario in sedges_inline ledge_inline overflow; do
+    for nodes in $NODE_SIZES; do
+      run_one "$BOOST_BIN" "$BOOST_CSV" add_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      run_one "$BOOST_BIN" "$BOOST_CSV" delete_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      run_one "$BOOST_BIN" "$BOOST_CSV" lookup_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      run_one "$BOOST_BIN" "$BOOST_CSV" traverse_fast_class "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      run_one "$BOOST_BIN" "$BOOST_CSV" traverse_forward_class "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      run_one "$BOOST_BIN" "$BOOST_CSV" traverse_backward_class "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    done
+  done
+}
+
+run_livehd_all() {
+  for nodes in $NODE_SIZES; do
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" add_nodes default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" add_nodes_with_pins default nodes "$nodes" 8 "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" lookup_nodes default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" delete_nodes_with_edges_and_pins default nodes "$nodes" 8 "$FIXED_HIER_SIZE" 0
+  done
+  for pins in $PIN_SIZES; do
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" add_pins default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" delete_pins default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" delete_pins_with_edges default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" lookup_pins default pins "$PIN_NODE_COUNT" "$pins" "$FIXED_HIER_SIZE" 0
+  done
+  for scenario in sedges_inline ledge_inline overflow; do
+    for nodes in $NODE_SIZES; do
+      run_one "$LIVEHD_BIN" "$LIVEHD_CSV" add_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      run_one "$LIVEHD_BIN" "$LIVEHD_CSV" delete_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      run_one "$LIVEHD_BIN" "$LIVEHD_CSV" lookup_edges "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      run_one "$LIVEHD_BIN" "$LIVEHD_CSV" traverse_fast_class "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      run_one "$LIVEHD_BIN" "$LIVEHD_CSV" traverse_forward_class "$scenario" nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+      # LiveHD's backward iterator is unimplemented -- skip; the comparison
+      # stage will fill those cells with N/A.
+    done
+  done
+  for nodes in $HIER_NODE_SIZES; do
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" traverse_fast_flat default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" traverse_forward_flat default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" traverse_fast_hier default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" traverse_forward_hier default nodes "$nodes" 1 "$FIXED_HIER_SIZE" 0
+  done
+  for hier in $HIER_SIZES; do
+    run_one "$LIVEHD_BIN" "$LIVEHD_CSV" traverse_hier_range default hier "$HIER_RANGE_NODE_COUNT" 1 "$hier" 0
+  done
+}
+
+echo "Launching three libraries in parallel..."
+run_hhds_all  > "$LOG_DIR/hhds.log"   2>&1 &
+HHDS_PID=$!
+run_boost_all > "$LOG_DIR/boost.log"  2>&1 &
+BOOST_PID=$!
+LIVEHD_PID=""
+if [[ "$LIVEHD_AVAILABLE" == "1" ]]; then
+  run_livehd_all > "$LOG_DIR/livehd.log" 2>&1 &
+  LIVEHD_PID=$!
+else
+  echo "Note: LiveHD binary not found at $LIVEHD_BIN -- livehd/results.csv stays header-only."
+fi
+
+echo "PIDs: HHDS=$HHDS_PID Boost=$BOOST_PID${LIVEHD_PID:+ LiveHD=$LIVEHD_PID}"
+echo ""
+echo "Per-library progress:"
+echo "  tail -f $LOG_DIR/hhds.log"
+echo "  tail -f $LOG_DIR/boost.log"
+[[ -n "$LIVEHD_PID" ]] && echo "  tail -f $LOG_DIR/livehd.log"
+echo ""
+echo "Waiting for all libraries to finish..."
+wait
+echo "All libraries done."
+
+echo ""
+echo "Building comparison.csv and plots..."
+"$PYTHON" "$BENCH_DIR/scripts/make_comparison.py" \
+  --hhds "$HHDS_CSV" \
+  --livehd "$LIVEHD_CSV" \
+  --boost "$BOOST_CSV" \
+  --out "$COMPARISON_CSV"
+
+"$PYTHON" "$BENCH_DIR/scripts/plot_results.py" \
+  --csv "$COMPARISON_CSV" \
+  --out-dir "$PLOT_DIR"
+
+echo ""
+echo "Done."
+echo "  Output folder:   $SMALL_DIR"
+echo "  Comparison CSV:  $COMPARISON_CSV"
+echo "  Plots:           $PLOT_DIR"
+echo "  Per-library logs:$LOG_DIR/{hhds,boost,livehd}.log"


### PR DESCRIPTION
## Summary

- Switch `plot_results.py` to **vector PDF** output with larger, thesis-grade typography and a fixed-position legend.
- Add a **smoke-test mode** + per-library size overrides + failure-tolerant cells + per-cell progress output to `run_all.sh`.
- Add `smaller_benchmarks/run_smaller.sh`, a **parallel companion runner** that exercises HHDS, Boost.Graph, and LiveHD concurrently on a smoother size sweep, writing into its own subtree so it does not collide with the canonical `run_all.sh` outputs.

## Motivation

While running the benchmark suite at scale for the thesis comparison, three pain points surfaced:

1. **PNG plots** with default Matplotlib font sizes were not legible in the printed document and pixelated under zoom.
2. The original `run_all.sh` was an all-or-nothing serial runner with no progress output, no way to probe the heaviest cells before committing to a multi-hour sweep, and no way to cap a library that crashes at scale (LiveHD's overflow cells, Boost's `O(N²)` node-delete path).
3. There was no way to run an alternative, smoother size sweep without overwriting the canonical results.

This PR addresses all three.

## What changed

### `hhds/benchmarks_final/scripts/plot_results.py`

- Output format switched from PNG to **vector PDF** (`.pdf`). DPI is no longer used.
- Font sizes scaled ~2× for thesis-grade readability:
  - title 24 pt, axis labels 22 pt, tick labels 20 pt, legend 18 pt.
- **Legend pinned outside the axes** as a horizontal 3-column row below the x-axis, so it never collides with any data line and is consistent across all subplots.
- `constrained_layout=True` replaces `tight_layout()` so the engine accounts for the out-of-axes legend.
- Figure size bumped to 8 × 6.5 in for more vertical room.

### `hhds/benchmarks_final/scripts/run_all.sh`

- **`SMOKE_ONLY=1`** mode runs the heaviest cells once each (per library × per node size) before committing to the full sweep. Each cell auto-times-out at 10 min (`timeout` / `gtimeout`, with macOS fallback).
- **Per-library size overrides**: `HHDS_NODE_SIZES`, `BOOST_NODE_SIZES`, `LIVEHD_NODE_SIZES` (and the equivalents for `PIN_SIZES`, `HIER_NODE_SIZES`, `HIER_SIZES`, `PIN_NODE_COUNT`). Default to the common values; useful to cap a library that crashes or scales pathologically.
- **Failure-tolerant `run_one`**: a crashing cell logs a `WARN:` line and the sweep continues, leaving `N/A` in the comparison CSV instead of aborting hours of work.
- **Per-cell progress output**: every cell prints a one-line status with elapsed seconds, so the operator can watch progress live or tail the output to a log file.
- Default sizes updated to be more representative; cells now run for several seconds of wall time at the largest size for almost every operation.

### `hhds/benchmarks_final/smaller_benchmarks/run_smaller.sh` (new file)

- Self-contained companion runner. Writes all artifacts (CSVs, plots, logs) under `smaller_benchmarks/` so it does **not** touch the canonical top-level outputs.
- Smoother size sweep: `NODE_SIZES="1000 5000 10000 50000 100000 500000 1000000 5000000"`, `PIN_SIZES="4 8 16 32 64"`, `RUNS=3`.
- Runs HHDS, Boost, LiveHD **in parallel** as three background jobs, each with its own progress log (`logs/{hhds,boost,livehd}.log`), then `wait`s and emits the merged comparison CSV and plot folder.
- Skips bazel rebuild and verifies the binaries exist instead; safe to run alongside the canonical `run_all.sh`.
- Reuses the same `make_comparison.py` / `plot_results.py` invocations.

## How to test

```bash
# Build the bench binaries (only once)
bazel build //hhds/benchmarks_final/hhds:hhds_final_bench \
            //hhds/benchmarks_final/boost:boost_final_bench

# Probe whether the heaviest cells survive at every NODE size (~5 min)
SMOKE_ONLY=1 bash hhds/benchmarks_final/scripts/run_all.sh

# Smaller, smoother sweep with all three libraries in parallel (~40 min)
bash hhds/benchmarks_final/smaller_benchmarks/run_smaller.sh

# Tail per-library progress
tail -f hhds/benchmarks_final/smaller_benchmarks/logs/hhds.log
```

After either sweep finishes, the renderer emits 33 vector PDFs alongside `comparison.csv` in the respective `comparisons/plot/` directory.

## Notes

- `plot_results.py` no longer takes a DPI argument. Downstream LaTeX includes should reference `.pdf` rather than `.png`.
- Smoke-test mode and the per-library overrides do not change the default behavior of `run_all.sh`; they are opt-in.
- The companion script's outputs live entirely under `smaller_benchmarks/` and are intentionally not committed in this PR (they are large and regeneratable). Only the script itself is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smoke test mode for faster benchmark validation with configurable timeout
  * New smaller benchmark suite with parallel execution across multiple libraries

* **Improvements**
  * Enhanced benchmark visualization with improved styling and PDF output
  * Better failure reporting with automatic cell skipping on errors
  * Added per-library configuration overrides for benchmark customization
  * Cleaner legend positioning in benchmark plots

<!-- end of auto-generated comment: release notes by coderabbit.ai -->